### PR TITLE
fix(docker): Replace gnu-libiconv-libs by gnu-libiconv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
   bash less vim geoip git tzdata zip curl \
   nginx nginx-mod-http-headers-more nginx-mod-http-geoip \
   nginx-mod-stream nginx-mod-stream-geoip ca-certificates \
-  libmcrypt gnu-libiconv-libs php-common \
+  libmcrypt gnu-libiconv php-common \
   && rm -rf /var/cache/apk/*
 
 # Install PHP requirements
@@ -33,7 +33,7 @@ RUN rm -rf /var/log/php* /etc/php*/php-fpm.conf /etc/php*/php-fpm.d
 # Configure php-fpm and nginx
 RUN mkdir -p /var/log/php /var/run/php /var/run/nginx /var/lib/nginx/tmp/client_body/ \
   && chown www-data:www-data /var/log/php /var/run/php \
-  && chown nginx:nginx /var/run/nginx \ 
+  && chown nginx:nginx /var/run/nginx \
   && chown -R www-data:nginx /var/lib/nginx/tmp/client_body \
   && chmod g+w /var/lib/nginx/tmp/client_body
 ADD ./assets/php-fpm.conf /usr/local/etc/php-fpm.conf

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Spin a Prestashop testing instance in seconds!
 
-> **⚠️ Disclaimer**: the following tool is provided in the solely purpose of bootstraping a PrestaShop testing environment. <br>If you look for a production grade image, please refer to https://github.com/PrestaShop/docker.
+> **⚠️ Disclaimer**: the following tool is provided in the sole purpose of bootstraping a PrestaShop testing environment. <br>If you look for a production grade image, please refer to https://github.com/PrestaShop/docker.
 
 > **Note**: no MySQL server is shipped in the resulting image, you have to provide your own instance for the backup to be dumped during the first connection.
 
@@ -130,7 +130,7 @@ Is working as expected. But what about the same request performed within the doc
 curl: (7) Failed to connect to localhost port 32000 after 5 ms: Couldn't connect to server
 ```
 
-Indeed this **WON'T WORK**, the container port is 80, only the host know about 8000 in our use case. Let's talk to it:
+Indeed, this **WON'T WORK**, the container port is 80, only the host know about 8000 in our use case. Let's talk to it:
 
 ```sh
 > docker exec -t prestashop curl -i 'http://localhost/index.php?fc=module&module=mymodule&controller=myctrl'
@@ -168,7 +168,7 @@ X-Powered-By: PHP/8.1.22
 Location: http://localhost:8000/
 ```
 
-or even better if you use an Nginx reverse-proxy to forward requests to prestashop within the internal docker network:
+or even better if you use a Nginx reverse-proxy to forward requests to prestashop within the internal docker network:
 
 ```nginx
 # so you can call "http://localhost:3000/prestashop/index.php" to reach your PrestaShop id_shop 1 with success


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | With apk (Dockerfile), `gnu-libiconv-libs` doesn't work anymore. I replaced it with `gnu-libiconv`
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | Enjoy with the build script
