### PR TITLE
Fix build tag generation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,2 @@
-.git
-docker-compose.yml
-Dockerfile
-*.md
+*
+!./assets

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ on:
         type: string
 
       php_version:
-        description: "The target PHP version (recommended version applies by default)"
+        description: "The target PHP version (recommended version applies by default, cf. build.sh)"
         required: false
         type: string
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ on:
         type: string
 
       php_version:
-        description: "The target PHP version (defaults to 'auto')"
+        description: "The target PHP version"
         required: false
         type: string
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,12 +28,12 @@ on:
         type: string
 
       php_version:
-        description: "The target PHP version"
+        description: "The target PHP version (recommended version applies by default)"
         required: false
         type: string
 
       tag:
-        description: "Docker tag (defaults to '$ps_version-$php_version' and/or 'latest')"
+        description: "Docker tag (defaults to '$ps_version-$php_version' or 'latest')"
         required: false
         type: string
 

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ TARGET_IMAGE=${TARGET_IMAGE:-"prestashop/prestashop-flashlight:${TAG}"}
 
 # Build builder common docker image
 # ---------------------------------
-echo docker buildx build \
+docker buildx build \
   --file ./Dockerfile \
   --platform "${PLATFORM:-linux/amd64}" \
   --build-arg PS_VERSION="${PS_VERSION}" \

--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ function get_recommended_php_version {
 }
 
 function get_tag {
-  TAG=${1:-}; PS_VERSION=${2:-}; PHP_VERSION=${3:-}
+  TAG=${1:-}; PS_VERSION=${2:-}; PHP_VERSION=${3:-};
   if [ "$PS_VERSION" == "latest" ] && [ "$PHP_VERSION" == "latest" ]; then
     echo "latest";
   elif [ -z "$PS_VERSION" ] && [ -z "$PHP_VERSION" ]; then
@@ -33,7 +33,7 @@ function get_tag {
   elif [ -n "$TAG" ]; then
     echo $TAG;
   else
-    echo "${PS_VERSION}-${PHP_VERSION}"
+    echo "auto"
   fi
 }
 
@@ -49,26 +49,26 @@ function get_ps_version {
 function get_php_version {
   PHP_VERSION=${1:-}; PS_VERSION=${2:-}
   if [ -z $PHP_VERSION ] || [ "$PHP_VERSION" == "latest" ] ; then
-    echo $(get_recommended_php_version $PS_VERSION);
-  else
-    echo $PHP_VERSION;
+    echo $(get_recommended_php_version $PS_VERSION)
   fi
+  echo $PHP_VERSION;
 }
 
 # Configuration
 # -------------
-TAG="$(get_tag ${TAG:-} ${PS_VERSION:-} ${PHP_VERSION:-})"
-TARGET_IMAGE=${TARGET_IMAGE:-"prestashop/prestashop-flashlight:${TAG}"}
-PS_VERSION="$(get_ps_version)"
-PHP_VERSION="$(get_php_version ${PHP_VERSION:-} $PS_VERSION)"
-
-if [[ -z $PHP_VERSION ]]; then
+TAG=$(get_tag "${TAG:-}" "${PS_VERSION}" "${PHP_VERSION}");
+PS_VERSION=$(get_ps_version "$PS_VERSION");
+PHP_VERSION=$(get_php_version "${PHP_VERSION:-}" "$PS_VERSION");
+if [ -z $PHP_VERSION ]; then
   error "Could not find a recommended PHP version for PS_VERSION: ${PS_VERSION}" 2
 fi
+[ "$TAG" == "auto" ] && TAG="${PS_VERSION}-${PHP_VERSION}";
+
+TARGET_IMAGE=${TARGET_IMAGE:-"prestashop/prestashop-flashlight:${TAG}"}
 
 # Build builder common docker image
 # ---------------------------------
-docker buildx build \
+echo docker buildx build \
   --file ./Dockerfile \
   --platform "${PLATFORM:-linux/amd64}" \
   --build-arg PS_VERSION="${PS_VERSION}" \

--- a/build.sh
+++ b/build.sh
@@ -56,8 +56,8 @@ function get_php_version {
 
 # Configuration
 # -------------
-TAG=$(get_tag "${TAG:-}" "${PS_VERSION}" "${PHP_VERSION}");
-PS_VERSION=$(get_ps_version "$PS_VERSION");
+TAG=$(get_tag "${TAG:-}" "${PS_VERSION:-}" "${PHP_VERSION:-}");
+PS_VERSION=$(get_ps_version "${PS_VERSION:-}");
 PHP_VERSION=$(get_php_version "${PHP_VERSION:-}" "$PS_VERSION");
 if [ -z $PHP_VERSION ]; then
   error "Could not find a recommended PHP version for PS_VERSION: ${PS_VERSION}" 2


### PR DESCRIPTION
Previously, build.sh was only generating "latest" as a valid tag. This fixes it.