### PR TITLE
fix(build): Add mcrypt extension to fix PrestaShop 1.6 RIJNDAEL required by back-office

### DIFF
--- a/assets/patch.sh
+++ b/assets/patch.sh
@@ -8,22 +8,6 @@ patch_1_6 () {
   # Add robots file
   echo "User-agent: *" > "${PS_FOLDER}/robots.txt"
   echo "Disallow: /" >> "${PS_FOLDER}/robots.txt"
-
-  # Fix the _RIJNDAEL_KEY_ warnings
-  sed -i "s/(_RIJNDAEL_KEY_, _RIJNDAEL_IV_)/('_RIJNDAEL_KEY_', '_RIJNDAEL_IV_')/" \
-    "$PS_FOLDER/classes/Cookie.php"
-  sed -i "s/MCRYPT_RIJNDAEL_128/'MCRYPT_RIJNDAEL_128'/" \
-    "$PS_FOLDER/classes/Rijndael.php"
-  sed -i "s/MCRYPT_MODE_CBC/'MCRYPT_MODE_CBC'/" \
-    "$PS_FOLDER/classes/Rijndael.php"
-
-  # Fix the Rijndael keys length
-   # shellcheck disable=SC2016
-  sed -i 's/$this->_key = $key/$this->_key = openssl_random_pseudo_bytes(32)/' \
-    "$PS_FOLDER/classes/Rijndael.php"
-  # shellcheck disable=SC2016
-  sed -i 's/$this->_iv = base64_decode($iv)/$this->_iv = openssl_random_pseudo_bytes(16)/' \
-    "$PS_FOLDER/classes/Rijndael.php"
 }
 
-echo "$PS_VERSION" | grep "^1.6" > /dev/null && patch_1_6 || echo "coucou"
+echo "$PS_VERSION" | grep "^1.6" > /dev/null && patch_1_6

--- a/assets/patch.sh
+++ b/assets/patch.sh
@@ -10,4 +10,6 @@ patch_1_6 () {
   echo "Disallow: /" >> "${PS_FOLDER}/robots.txt"
 }
 
-echo "$PS_VERSION" | grep "^1.6" > /dev/null && patch_1_6
+if echo "$PS_VERSION" | grep "^1.6" > /dev/null; then
+  patch_1_6;
+fi

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -20,8 +20,10 @@ RUN apk --no-cache add -U \
 # Install PHP requirements
 # see: https://olvlvl.com/2019-06-install-php-ext-source
 RUN apk --no-cache add -U zlib-dev libjpeg-turbo-dev libpng-dev libzip-dev icu-dev libmcrypt-dev \
-  && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-configure gd --with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir || docker-php-ext-configure gd --with-jpeg) \
-  && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-install gd pdo_mysql zip intl mcrypt || docker-php-ext-install gd pdo_mysql zip intl);
+  && if [ "7.1" = "$PHP_VERSION" ]; then docker-php-ext-configure gd --with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir && docker-php-ext-install gd pdo_mysql zip intl mcrypt; \
+  else \
+  docker-php-ext-configure gd --with-jpeg && docker-php-ext-install gd pdo_mysql zip intl; \
+  fi;
 
 # TODO check opcache configuration
 # RUN docker-php-ext-enable opcache

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -15,13 +15,13 @@ RUN apk --no-cache add -U \
   bash less vim geoip git tzdata zip curl jq \
   nginx nginx-mod-http-headers-more nginx-mod-http-geoip \
   nginx-mod-stream nginx-mod-stream-geoip ca-certificates \
-  libmcrypt libmcrypt-dev gnu-libiconv php-common mariadb-client sudo
+  libmcrypt gnu-libiconv php-common mariadb-client sudo
 
 # Install PHP requirements
 # see: https://olvlvl.com/2019-06-install-php-ext-source
-RUN apk --no-cache add -U zlib-dev libjpeg-turbo-dev libpng-dev libzip-dev icu-dev \
+RUN apk --no-cache add -U zlib-dev libjpeg-turbo-dev libpng-dev libzip-dev icu-dev libmcrypt-dev \
   && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-configure gd --with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir || docker-php-ext-configure gd --with-jpeg) \
-  && docker-php-ext-install gd pdo_mysql zip intl mcrypt;
+  && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-install gd pdo_mysql zip intl mcrypt || && docker-php-ext-install gd pdo_mysql zip intl);
 
 # TODO check opcache configuration
 # RUN docker-php-ext-enable opcache

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -15,13 +15,13 @@ RUN apk --no-cache add -U \
   bash less vim geoip git tzdata zip curl jq \
   nginx nginx-mod-http-headers-more nginx-mod-http-geoip \
   nginx-mod-stream nginx-mod-stream-geoip ca-certificates \
-  libmcrypt gnu-libiconv php-common mariadb-client sudo
+  gnu-libiconv php-common mariadb-client sudo
 
 # Install PHP requirements
 # see: https://olvlvl.com/2019-06-install-php-ext-source
 RUN apk --no-cache add -U zlib-dev libjpeg-turbo-dev libpng-dev libzip-dev icu-dev libmcrypt-dev \
   && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-configure gd --with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir || docker-php-ext-configure gd --with-jpeg) \
-  && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-install gd pdo_mysql zip intl mcrypt || && docker-php-ext-install gd pdo_mysql zip intl);
+  && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-install gd pdo_mysql zip intl mcrypt || docker-php-ext-install gd pdo_mysql zip intl);
 
 # TODO check opcache configuration
 # RUN docker-php-ext-enable opcache

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -15,13 +15,13 @@ RUN apk --no-cache add -U \
   bash less vim geoip git tzdata zip curl jq \
   nginx nginx-mod-http-headers-more nginx-mod-http-geoip \
   nginx-mod-stream nginx-mod-stream-geoip ca-certificates \
-  libmcrypt gnu-libiconv php-common mariadb-client sudo
+  libmcrypt libmcrypt-dev gnu-libiconv php-common mariadb-client sudo
 
 # Install PHP requirements
 # see: https://olvlvl.com/2019-06-install-php-ext-source
 RUN apk --no-cache add -U zlib-dev libjpeg-turbo-dev libpng-dev libzip-dev icu-dev \
   && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-configure gd --with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir || docker-php-ext-configure gd --with-jpeg) \
-  && docker-php-ext-install gd pdo_mysql zip intl;
+  && docker-php-ext-install gd pdo_mysql zip intl mcrypt;
 
 # TODO check opcache configuration
 # RUN docker-php-ext-enable opcache

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -13,7 +13,7 @@ ENV PS_FOLDER=/var/www/html
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy \
   bash less vim git tzdata zip unzip curl jq netcat-traditional ca-certificates \
-  lsb-release libgnutls30 gnupg libmcrypt4 libiconv-hook1 \
+  lsb-release libgnutls30 gnupg libmcrypt4 libmcrypt-dev libiconv-hook1 \
   nginx libnginx-mod-http-headers-more-filter libnginx-mod-http-geoip \
   libnginx-mod-http-geoip libnginx-mod-stream mariadb-client sudo
 
@@ -30,7 +30,7 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-configure gd --with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir || docker-php-ext-configure gd --with-jpeg) \
-  && docker-php-ext-install gd pdo_mysql zip intl;
+  && docker-php-ext-install gd pdo_mysql zip intl mcrypt;
 
 # Configure php-fpm and nginx
 RUN rm -rf /var/log/php* /etc/php*/php-fpm.conf /etc/php*/php-fpm.d \

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -13,7 +13,7 @@ ENV PS_FOLDER=/var/www/html
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy \
   bash less vim git tzdata zip unzip curl jq netcat-traditional ca-certificates \
-  lsb-release libgnutls30 gnupg libmcrypt4 libmcrypt-dev libiconv-hook1 \
+  lsb-release libgnutls30 gnupg libiconv-hook1 \
   nginx libnginx-mod-http-headers-more-filter libnginx-mod-http-geoip \
   libnginx-mod-http-geoip libnginx-mod-stream mariadb-client sudo
 
@@ -26,11 +26,11 @@ RUN curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.or
   && echo "deb [trusted=yes] https://packages.sury.org/php/ ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/php.list \
   && rm /etc/apt/preferences.d/no-debian-php;
 RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy php-gd libghc-zlib-dev libjpeg-dev libpng-dev libzip-dev libicu-dev \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy php-gd libghc-zlib-dev libjpeg-dev libpng-dev libzip-dev libicu-dev libmcrypt-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-configure gd --with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir || docker-php-ext-configure gd --with-jpeg) \
-  && docker-php-ext-install gd pdo_mysql zip intl mcrypt;
+  && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-install gd pdo_mysql zip intl mcrypt || && docker-php-ext-install gd pdo_mysql zip intl)
 
 # Configure php-fpm and nginx
 RUN rm -rf /var/log/php* /etc/php*/php-fpm.conf /etc/php*/php-fpm.d \

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-configure gd --with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir || docker-php-ext-configure gd --with-jpeg) \
-  && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-install gd pdo_mysql zip intl mcrypt || && docker-php-ext-install gd pdo_mysql zip intl)
+  && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-install gd pdo_mysql zip intl mcrypt || docker-php-ext-install gd pdo_mysql zip intl)
 
 # Configure php-fpm and nginx
 RUN rm -rf /var/log/php* /etc/php*/php-fpm.conf /etc/php*/php-fpm.d \

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -29,8 +29,10 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy php-gd libghc-zlib-dev libjpeg-dev libpng-dev libzip-dev libicu-dev libmcrypt-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
-  && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-configure gd --with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir || docker-php-ext-configure gd --with-jpeg) \
-  && ([ "7.1" = "$PHP_VERSION" ] && docker-php-ext-install gd pdo_mysql zip intl mcrypt || docker-php-ext-install gd pdo_mysql zip intl)
+  && if [ "7.1" = "$PHP_VERSION" ]; then docker-php-ext-configure gd --with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir && docker-php-ext-install gd pdo_mysql zip intl mcrypt; \
+  else \
+  docker-php-ext-configure gd --with-jpeg && docker-php-ext-install gd pdo_mysql zip intl; \
+  fi;
 
 # Configure php-fpm and nginx
 RUN rm -rf /var/log/php* /etc/php*/php-fpm.conf /etc/php*/php-fpm.d \


### PR DESCRIPTION
The `mcrypt` PHP extension was missing, hence the errors with the PS 1.6 backoffice.