### PR TITLE
chore(github): Disable push by tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,6 @@
 name: Docker image publish
 
 on:
-  push:
-    tags: ["v*.*.*"]
   workflow_dispatch:
     inputs:
       flavour:


### PR DESCRIPTION
This package will never have such thing as "versioning" as this is a pure bundler, not a product in essence.