### PR TITLE
fix(run): nginx redirect fix

### DIFF
--- a/assets/nginx.conf
+++ b/assets/nginx.conf
@@ -95,7 +95,7 @@ http {
 
     # PrestaShop admin URL 
     location = /ps-admin {
-      rewrite ^ /ps-admin/index.php last;
+      rewrite ^ $scheme://$http_host/ps-admin/index.php redirect;
     }
 
     location /ps-admin/ {


### PR DESCRIPTION
Redirecting should be performed with a 302, otherwise /ps-admin won't be resolved as index.php or will mess up with relative paths.