### PR TITLE
chore(build): fix latest docker tag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -90,8 +90,9 @@ get_target_images() {
   local PS_VERSION=${3:-};
   local PHP_VERSION=${4:-};
   local OS_FLAVOUR=${5:-};
+  local LATEST=${6:-};
   declare RES;
-  [ "$TAG" == "latest" ] && RES="-t ${DEFAULT_DOCKER_IMAGE}:latest";
+  [ "$LATEST" = "true" ] && [ "$OS_FLAVOUR" = "alpine" ] && RES="-t ${DEFAULT_DOCKER_IMAGE}:latest";
   [[ "$PHP_FLAVOUR" == *"$DEFAULT_OS" ]] && RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}-${PHP_VERSION}";
   RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}-${PHP_FLAVOUR}";
   RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}-${OS_FLAVOUR}";
@@ -106,7 +107,9 @@ PHP_VERSION=$(get_php_version "$PHP_VERSION" "$PS_VERSION");
 if [ -z "$PHP_VERSION" ]; then
   error "Could not find a recommended PHP version for PS_VERSION: $PS_VERSION" 2
 fi
-[ "$TAG" == "auto" ] && TAG="$PS_VERSION-$PHP_VERSION";
+declare LATEST;
+[ "$TAG" = "latest" ] && LATEST="true";
+[ "$TAG" = "auto" ] && LATEST="true" && TAG="$PS_VERSION-$PHP_VERSION";
 OS_FLAVOUR=${OS_FLAVOUR:-$DEFAULT_OS};
 SERVER_FLAVOUR=${SERVER_FLAVOUR:-$DEFAULT_SERVER};
 PHP_FLAVOUR=$(get_php_flavour "$OS_FLAVOUR" "$SERVER_FLAVOUR" "$PHP_VERSION");
@@ -114,7 +117,7 @@ if [ "$PHP_FLAVOUR" == "null" ]; then
   error "Could not find a PHP flavour for $OS_FLAVOUR + $SERVER_FLAVOUR + $PHP_VERSION" 2;
 fi
 if [ -z "${TARGET_IMAGE:+x}" ]; then
-  read -ra TARGET_IMAGES <<<"$(get_target_images "$TAG" "$PHP_FLAVOUR" "$PS_VERSION" "$PHP_VERSION" "$OS_FLAVOUR")"
+  read -ra TARGET_IMAGES <<<"$(get_target_images "$TAG" "$PHP_FLAVOUR" "$PS_VERSION" "$PHP_VERSION" "$OS_FLAVOUR" "$LATEST")"
 else
   read -ra TARGET_IMAGES <<<"-t $TARGET_IMAGE"
 fi


### PR DESCRIPTION
The `:latest` tag was not set yet, hence very useful for developers. The latest tag sounds for the latest PrestaShop version officially released, and stands for an alpine linux build with nginx.