### PR TITLE
chore(build): PS_VERSION as a tag if the recommended PHP version is used

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,7 +93,12 @@ get_target_images() {
   local LATEST=${6:-};
   declare RES;
   [ "$LATEST" = "true" ] && [ "$OS_FLAVOUR" = "alpine" ] && RES="-t ${DEFAULT_DOCKER_IMAGE}:latest";
-  [[ "$PHP_FLAVOUR" == *"$DEFAULT_OS" ]] && RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}-${PHP_VERSION}";
+  if [ "$OS_FLAVOUR" = "$DEFAULT_OS" ]; then
+    RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}-${PHP_VERSION}";
+    if [ "$PHP_VERSION" = "$(get_recommended_php_version "$PS_VERSION")" ]; then
+      RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}"; 
+    fi
+  fi
   RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}-${PHP_FLAVOUR}";
   RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}-${OS_FLAVOUR}";
   echo "$RES";


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Getting tags with the PrestaShop version is more handy, and will stand for the default OS_FLAVOUR (alpine linux) and for the recommended PHP version.
| Type?             | packaging
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | ./build.sh && docker images
