### PR TITLE
feat(tooling): add php-cs-fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,6 @@ server {
 - https://github.com/PrestaShop/PrestaShop
 - https://github.com/PrestaShop/performance-project
 - https://github.com/jokesterfr/docker-prestashop
+- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer
+- https://github.com/sebastianbergmann/phpunit
+- https://github.com/phpstan/phpstan

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -53,6 +53,11 @@ RUN PHPSTAN_VERSION=$(jq -r '."'"${PHP_VERSION}"'".phpstan' < /tmp/php-flavours.
   && wget -q -O /usr/bin/phpstan "https://github.com/phpstan/phpstan/raw/${PHPSTAN_VERSION}/phpstan.phar" \
   && chmod a+x /usr/bin/phpstan
 
+# Install php-cs-fixer
+RUN PHP_CS_FIXER=$(jq -r '."'"${PHP_VERSION}"'".php_cs_fixer' < /tmp/php-flavours.json) \
+  && wget -q -O /usr/bin/php-cs-fixer "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/${PHP_CS_FIXER}/php-cs-fixer.phar" \
+  && chmod a+x /usr/bin/php-cs-fixer
+
 # --------------------------------
 # Flashlight install and dump SQL
 # --------------------------------

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -59,6 +59,11 @@ RUN PHPSTAN_VERSION=$(jq -r '."'"${PHP_VERSION}"'".phpstan' < /tmp/php-flavours.
   && wget -q -O /usr/bin/phpstan "https://github.com/phpstan/phpstan/raw/${PHPSTAN_VERSION}/phpstan.phar" \
   && chmod a+x /usr/bin/phpstan
 
+# Install php-cs-fixer
+RUN PHP_CS_FIXER=$(jq -r '."'"${PHP_VERSION}"'".php_cs_fixer' < /tmp/php-flavours.json) \
+  && wget -q -O /usr/bin/php-cs-fixer "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/${PHP_CS_FIXER}/php-cs-fixer.phar" \
+  && chmod a+x /usr/bin/php-cs-fixer
+
 # --------------------------------
 # Flashlight install and dump SQL
 # --------------------------------

--- a/php-flavours.json
+++ b/php-flavours.json
@@ -2,48 +2,56 @@
   "7.1": {
     "alpine": "7.1-fpm-alpine",
     "debian": "7.1-fpm-buster",
+    "php_cs_fixer": "v3.3.0",
     "phpstan": "1.4.10",
     "phpunit": "7.5.20"
   },
   "7.2": {
     "alpine": "7.2-fpm-alpine",
     "debian": "7.2-fpm-buster",
+    "php_cs_fixer": "v3.4.0",
     "phpstan": "HEAD",
     "phpunit": "8.5.34"
   },
   "7.3": {
     "alpine": "7.3-fpm-alpine",
     "debian": "7.3-fpm-buster",
+    "php_cs_fixer": "v3.4.0",
     "phpstan": "HEAD",
     "phpunit": "9.6.13"
   },
   "7.4": {
     "alpine": "7.4-fpm-alpine",
     "debian": "7.4-fpm-buster",
+    "php_cs_fixer": "v3.40.0",
     "phpstan": "HEAD",
     "phpunit": "9.6.13"
   },
   "8.0": {
     "alpine": "8.0-fpm-alpine",
     "debian": "8.0-fpm-bullseye",
+    "php_cs_fixer": "v3.40.0",
     "phpstan": "HEAD",
     "phpunit": "9.6.13"
   },
   "8.1": {
     "alpine": "8.1-fpm-alpine",
     "debian": "8.1-fpm-bookworm",
+    "php_cs_fixer": "v3.40.0",
     "phpstan": "HEAD",
     "phpunit": "10.4.2"
   },
   "8.2": {
     "alpine": "8.2-fpm-alpine",
     "debian": "8.2-fpm-bookworm",
+    "php_cs_fixer": "v3.40.0",
     "phpstan": "HEAD",
     "phpunit": "10.4.2"
   },
   "8.3": {
     "alpine": "8.3-fpm-alpine",
     "debian": "8.3-fpm-bookworm",
+    "php_cs_fixer": "v3.40.0",
     "phpstan": "HEAD",
     "phpunit": "10.4.2"
   }


### PR DESCRIPTION
PHP CS fixer is usually used to lint PHP files.