### PR TITLE
chore(packaging): publish a php-x.y tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A few examples are available in the [examples](./examples) folder.
 | ON_INSTALL_MODULES_FAILURE | if set to `continue`, module installation failure will not block the init process                        | no                                          | `fail`                                |
 | DRY_RUN                    | if enabled, the run.sh script will exit without really starting a web server                             | no                                          | `false`                               |
 
-# Develop
+# Contribute
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -216,11 +216,18 @@ server {
 }
 ```
 
+# Compatibility
+
+PrestaShop Flashlight is based on the official compatibility charts:
+
+- PrestaShop 1.6-1.7.x [PHP compatiblity chart](https://devdocs.prestashop-project.org/1.7/basics/installation/system-requirements/#php-compatibility-chart)
+- PrestaShop 8.x [PHP compatiblity chart](https://devdocs.prestashop-project.org/8/basics/installation/system-requirements/#php-compatibility-chart)
+
+You can check this implementation anytime in [prestashop-version.json](./prestashop-version.json).
+
 # Credits
 
 - https://github.com/PrestaShop/PrestaShop
 - https://github.com/PrestaShop/performance-project
 - https://github.com/jokesterfr/docker-prestashop
-- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer
-- https://github.com/sebastianbergmann/phpunit
-- https://github.com/phpstan/phpstan
+- https://github.com/PrestaShop/php-dev-tools

--- a/build.sh
+++ b/build.sh
@@ -72,6 +72,7 @@ get_php_version() {
 #
 # if the build is for the latest image of the default OS with the recommended PHP version, these tags will be like:
 # * latest
+# * php-8.2
 # * 8.1.1
 # * 8.1.1-8.2
 # * 8.1.1-8.2-alpine
@@ -89,6 +90,7 @@ get_target_images() {
     RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}-${PHP_VERSION}";
     if [ "$PHP_VERSION" = "$(get_recommended_php_version "$PS_VERSION")" ]; then
       RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}";
+      RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:php-${PHP_VERSION}";
     fi
   fi
   RES="${RES} -t ${DEFAULT_DOCKER_IMAGE}:${PS_VERSION}-${PHP_FLAVOUR}";


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When the PHP version is the recommended PHP version and when the OS_FLAVOUR is the default one, the build.sh script will also generate a `php-x.y` tag. If PrestaShop 8.1 has PHP 8.1 recommended, the `php:8.1` tag will be bound to this image.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | docker pull prestashop/prestashop-flashlight:php-8.1
