### PR TITLE
chore(composer): set rights for www-data to modify $COMPOSER_HOME

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -114,6 +114,10 @@ ENV MYSQL_DATABASE=prestashop
 ENV DEBUG_MODE=false
 ENV PS_FOLDER=$PS_FOLDER
 ENV MYSQL_EXTRA_DUMP=
+ENV COMPOSER_HOME=/var/composer
+
+RUN mkdir $COMPOSER_HOME \
+  && chown www-data:www-data $COMPOSER_HOME
 
 # Get the installed sources
 COPY \
@@ -129,7 +133,7 @@ COPY --chown=www-data:www-data \
 # The new default runner
 COPY ./assets/run.sh /run.sh
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=10 --start-period=10s \
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 --start-period=10s \
   CMD curl -Isf http://localhost:80/robots.txt || exit 1
 EXPOSE 80
 STOPSIGNAL SIGQUIT

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -122,6 +122,10 @@ ENV MYSQL_DATABASE=prestashop
 ENV DEBUG_MODE=false
 ENV PS_FOLDER=$PS_FOLDER
 ENV MYSQL_EXTRA_DUMP=
+ENV COMPOSER_HOME=/var/composer
+
+RUN mkdir $COMPOSER_HOME \
+  && chown www-data:www-data $COMPOSER_HOME
 
 # Get the installed sources
 COPY \
@@ -137,7 +141,7 @@ COPY --chown=www-data:www-data \
 # The new default runner
 COPY ./assets/run.sh /run.sh
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=10 --start-period=10s \
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 --start-period=10s \
   CMD curl -Isf http://localhost:80/robots.txt || exit 1
 EXPOSE 80
 STOPSIGNAL SIGQUIT


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When you use composer after dropping rights to www-data, you cannot save the composer cache in the root location. Therefore defining $COMPOSER_HOME may help if you intend to use composer calls in any init-scripts or post-scripts.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | call `composer install` in an init-script
