### PR TITLE
feat(run): ease mounting $PS_FOLDER entirely

### DIFF
--- a/assets/hydrate.sh
+++ b/assets/hydrate.sh
@@ -100,5 +100,5 @@ mkdir /var/opt/prestashop
 if [ -f "$PS_FOLDER/app/config/parameters.php" ]; then
   cp "$PS_FOLDER/app/config/parameters.php" /var/opt/prestashop/parameters.php
 elif [ -f "$PS_FOLDER/config/settings.inc.php" ]; then
-  cp "$PS_FOLDER/app/config/parameters.php" /var/opt/prestashop/parameters.php
+  cp "$PS_FOLDER/config/settings.inc.php" /var/opt/prestashop/parameters.php
 fi

--- a/assets/hydrate.sh
+++ b/assets/hydrate.sh
@@ -94,3 +94,11 @@ rm -rf \
   "$PS_LOGS_DIR"
 mkdir -p "$PS_CACHE_DIR" "$PS_LOGS_DIR"
 chown -R www-data:www-data "$PS_CACHE_DIR" "$PS_LOGS_DIR"
+
+# 12. Protect our settings against a volume mount on $PS_FOLDER
+mkdir /var/opt/prestashop
+if [ -f "$PS_FOLDER/app/config/parameters.php" ]; then
+  cp "$PS_FOLDER/app/config/parameters.php" /var/opt/prestashop/parameters.php
+elif [ -f "$PS_FOLDER/config/settings.inc.php" ]; then
+  cp "$PS_FOLDER/app/config/parameters.php" /var/opt/prestashop/parameters.php
+fi


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If you want to mount the whole $PS_FOLDER directory while running PrestaShop Flashlight, you may encounter issues. Either (1) your local configuration could be overriden and lost or (2), you would miss any configuration. For (1) we perform a backup file, and (2) search for a built version of the parameters to write it in your local volume. Such usage was not expected in early design stages of Flashlight, but are welcome to provide new use cases.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Sponsor company   | The Core team
| How to test?      | Mount your PrestaShop sources in flashlight with a docker volume to try it out.
