### PR TITLE
fix(build): target platform is no longer a build-arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ For a custom multi-platform build & push:
 
 ```sh
 PS_VERSION=8.1.0 \
-TARGETPLATFORM=linux/amd64,linux/arm64 \
+TARGET_PLATFORM=linux/amd64,linux/arm64 \
 PUSH=true \
 TARGET_IMAGE=my-own-repo/testing:latest \
 ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,8 @@ declare PUSH;            # -- set it to "true" if you want to push the resulting
 DEFAULT_OS="alpine";
 DEFAULT_SERVER="nginx";
 DEFAULT_DOCKER_IMAGE=prestashop/prestashop-flashlight
-DEFAULT_PLATFORM=linux/amd64
+DEFAULT_PLATFORM=$(docker system info --format '{{.OSType}}/{{.Architecture}}')
+docker system info --format '{{.OSType}}/{{.Architecture}}'
 GIT_SHA=$(git rev-parse HEAD)
 TARGET_PLATFORM="${TARGET_PLATFORM:-$DEFAULT_PLATFORM}"
 [ -n "$PLATFORM" ] && TARGET_PLATFORM=$PLATFORM;
@@ -148,7 +149,6 @@ docker buildx build \
   --build-arg PHP_VERSION="$PHP_VERSION" \
   --build-arg GIT_SHA="$GIT_SHA" \
   --build-arg NODE_VERSION="$NODE_VERSION" \
-  --build-arg TARGET_PLATFORM="$TARGET_PLATFORM" \
   --label org.opencontainers.image.title="PrestaShop Flashlight" \
   --label org.opencontainers.image.description="PrestaShop Flashlight testing utility" \
   --label org.opencontainers.image.source=https://github.com/PrestaShop/prestashop-flashlight \

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -3,7 +3,6 @@ ARG PHP_VERSION
 ARG PHP_FLAVOUR
 ARG GIT_SHA
 ARG NODE_VERSION
-ARG TARGET_PLATFORM
 
 # -------------------------------------
 #  PrestaShop Flashlight: Alpine image
@@ -12,7 +11,6 @@ FROM php:${PHP_FLAVOUR} AS base-prestashop
 ARG PS_VERSION
 ARG PHP_VERSION
 ARG NODE_VERSION
-ARG TARGET_PLATFORM
 ENV PS_FOLDER=/var/www/html
 ENV PHP_INI_DIR=/usr/local/etc/php
 ENV COMPOSER_HOME=/var/composer
@@ -70,9 +68,9 @@ RUN PHP_CS_FIXER=$(jq -r '."'"${PHP_VERSION}"'".php_cs_fixer' < /tmp/php-flavour
 ENV PATH "$PATH:/usr/local/lib/nodejs/bin"
 RUN if [ "0.0.0" = "$NODE_VERSION" ]; then exit 0; fi \
   && apk --no-cache add -U gcompat \
-  && if [ "linux/arm64" = "$TARGET_PLATFORM" ]; \
-  then export DISTRO="linux-arm64"; \
-  else export DISTRO="linux-x64"; \
+  && if [ "$(arch)" = "x86_64" ]; \
+  then export DISTRO="linux-x64"; \
+  else export DISTRO="linux-arm64"; \
   fi \
   && curl --silent --show-error --fail --location --output /tmp/node.tar.xz \
   "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${DISTRO}.tar.xz" \

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -3,7 +3,6 @@ ARG PHP_VERSION
 ARG PHP_FLAVOUR
 ARG GIT_SHA
 ARG NODE_VERSION
-ARG TARGET_PLATFORM
 
 # -------------------------------------
 #  PrestaShop Flashlight: Debian image
@@ -13,7 +12,6 @@ ARG PS_VERSION
 ARG PHP_VERSION
 ARG GIT_SHA
 ARG NODE_VERSION
-ARG TARGET_PLATFORM
 ENV PS_FOLDER=/var/www/html
 ENV COMPOSER_HOME=/var/composer
 
@@ -82,9 +80,9 @@ RUN PHP_CS_FIXER=$(jq -r '."'"${PHP_VERSION}"'".php_cs_fixer' < /tmp/php-flavour
 # Install Node.js and pnpm (yarn and npm are included)
 ENV PATH "$PATH:/usr/local/lib/nodejs/bin"
 RUN if [ "0.0.0" = "$NODE_VERSION" ]; then exit 0; fi \
-  && if [ "linux/arm64" = "$TARGET_PLATFORM" ]; \
-  then export DISTRO="linux-arm64"; \
-  else export DISTRO="linux-x64"; \
+  && if [ "$(arch)" = "x86_64" ]; \
+  then export DISTRO="linux-x64"; \
+  else export DISTRO="linux-arm64"; \
   fi \
   && curl --silent --show-error --fail --location --output /tmp/node.tar.xz \
   "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${DISTRO}.tar.xz" \

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 publish() {
   gh workflow run docker-publish.yml \
-  --repo prestashop/prestashop-flashlight "$@"
+  --repo prestashop/prestashop-flashlight \
+  --field target_platforms=linux/amd64,linux/arm64 "$@"
 }
 
 publish --field ps_version=latest


### PR DESCRIPTION
A subtle issue was raised during the docker image publish operation, but was not catched by the CI checks.

This is because TARGET_PLATFORM was used as a combined string "linux/arm64,linux/amd64", and could not correctly be parsed in the Dockerfiles scripts.

To really solve this issue, I found more relevant to definitely rely on the OS than to provide error prone external variables : using `arch` command helps to figure out which arch is running during the Dockerfile build... Even in platform compatibility mode (target arch != build arch).
