### PR TITLE
fix(chore): fixes #48 add a cross-compilation test

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -62,3 +62,17 @@ jobs:
         run: docker run --env PS_DOMAIN='localhost:80' --entrypoint phpstan $DOCKER_IMAGE --version
         env:
           DOCKER_IMAGE: prestashop/prestashop-flashlight:${{ matrix.ps_version }}-${{ matrix.os_flavour }}
+
+  docker_build_cross_compile:
+    name: "Docker build x-compile for aarch64"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Test the docker build chain while cross compiling to aarch64
+        run: ./build.sh
+        env:
+          OS_FLAVOUR: "alpine"
+          PS_VERSION: "8.1.2"
+          TARGET_PLATFORM: "linux/arm64"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -70,6 +70,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: "linux/amd64,linux/arm64"
+          use: true
+
       - name: Test the docker build chain while cross compiling to aarch64
         run: ./build.sh
         env:

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ TARGET_IMAGE=my-own-repo/testing:latest \
 Init buildx:
 
 ```sh
-docker buildx create --use
+docker buildx create --name mybuilder --use --platform linux/amd64,linux/arm64 
 ```
 
 Then:

--- a/assets/hydrate.sh
+++ b/assets/hydrate.sh
@@ -83,7 +83,7 @@ else
 fi
 
 # 10. Tear down mysql
-killall mysqld;
+killall --wait --quiet mysqld | true
 
 # 11. Some clean up
 mv "${PS_FOLDER}/admin" "${PS_FOLDER}/${PS_FOLDER_ADMIN}"

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -67,16 +67,7 @@ RUN PHP_CS_FIXER=$(jq -r '."'"${PHP_VERSION}"'".php_cs_fixer' < /tmp/php-flavour
 # Install Node.js and pnpm (yarn and npm are included)
 ENV PATH "$PATH:/usr/local/lib/nodejs/bin"
 RUN if [ "0.0.0" = "$NODE_VERSION" ]; then exit 0; fi \
-  && apk --no-cache add -U gcompat \
-  && if [ "$(arch)" = "x86_64" ]; \
-  then export DISTRO="linux-x64"; \
-  else export DISTRO="linux-arm64"; \
-  fi \
-  && curl --silent --show-error --fail --location --output /tmp/node.tar.xz \
-  "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${DISTRO}.tar.xz" \
-  && mkdir -p /tmp/nodejs && tar -xJf /tmp/node.tar.xz -C /tmp/nodejs \
-  && mv "/tmp/nodejs/node-v${NODE_VERSION}-${DISTRO}" /usr/local/lib/nodejs \
-  && rm -rf /tmp/nodejs /tmp/node.tar.xz \
+  && apk --no-cache add -U python3 nodejs \
   && npm install -g yarn@latest pnpm@latest --force
 
 # --------------------------------

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -65,10 +65,9 @@ RUN PHP_CS_FIXER=$(jq -r '."'"${PHP_VERSION}"'".php_cs_fixer' < /tmp/php-flavour
   && chmod a+x /usr/bin/php-cs-fixer
 
 # Install Node.js and pnpm (yarn and npm are included)
-ENV PATH "$PATH:/usr/local/lib/nodejs/bin"
 RUN if [ "0.0.0" = "$NODE_VERSION" ]; then exit 0; fi \
-  && apk --no-cache add -U python3 nodejs \
-  && npm install -g yarn@latest pnpm@latest --force
+  && apk --no-cache add -U python3 nodejs npm yarn \
+  && npm install -g pnpm@latest
 
 # --------------------------------
 # Flashlight install and dump SQL

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -83,7 +83,7 @@ RUN PHP_CS_FIXER=$(jq -r '."'"${PHP_VERSION}"'".php_cs_fixer' < /tmp/php-flavour
 RUN if [ "0.0.0" = "$NODE_VERSION" ]; then exit 0; fi \
   && export DEBIAN_FRONTEND=noninteractive \ 
   && apt-get update \
-  && apt-get install --no-install-recommends -qqy nodejs python3 \
+  && apt-get install --no-install-recommends -qqy nodejs python3 npm \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && npm install -g yarn@latest pnpm@latest --force

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -16,8 +16,9 @@ ENV PS_FOLDER=/var/www/html
 ENV COMPOSER_HOME=/var/composer
 
 # Update certificates
-RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy \
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get install --no-install-recommends -qqy \
   ca-certificates bash less vim git tzdata zip unzip curl wget make jq netcat-traditional \
   lsb-release libgnutls30 gnupg libiconv-hook1 \
   nginx libnginx-mod-http-headers-more-filter libnginx-mod-http-geoip \
@@ -30,8 +31,9 @@ RUN apt-get update \
 RUN . /etc/os-release \
   && echo "deb [trusted=yes] https://packages.sury.org/php/ ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/php.list \
   && rm /etc/apt/preferences.d/no-debian-php \
-  && DEBIAN_FRONTEND=noninteractive apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get install --no-install-recommends -qqy \
   php-gd libghc-zlib-dev libjpeg-dev libpng-dev libzip-dev libicu-dev libmcrypt-dev libxml2-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
@@ -78,17 +80,12 @@ RUN PHP_CS_FIXER=$(jq -r '."'"${PHP_VERSION}"'".php_cs_fixer' < /tmp/php-flavour
   && chmod a+x /usr/bin/php-cs-fixer
 
 # Install Node.js and pnpm (yarn and npm are included)
-ENV PATH "$PATH:/usr/local/lib/nodejs/bin"
 RUN if [ "0.0.0" = "$NODE_VERSION" ]; then exit 0; fi \
-  && if [ "$(arch)" = "x86_64" ]; \
-  then export DISTRO="linux-x64"; \
-  else export DISTRO="linux-arm64"; \
-  fi \
-  && curl --silent --show-error --fail --location --output /tmp/node.tar.xz \
-  "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${DISTRO}.tar.xz" \
-  && mkdir -p /tmp/nodejs && tar -xJf /tmp/node.tar.xz -C /tmp/nodejs \
-  && mv "/tmp/nodejs/node-v${NODE_VERSION}-${DISTRO}" /usr/local/lib/nodejs \
-  && rm -rf /tmp/nodejs /tmp/node.tar.xz \
+  && export DEBIAN_FRONTEND=noninteractive \ 
+  && apt-get update \
+  && apt-get install --no-install-recommends -qqy nodejs python3 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
   && npm install -g yarn@latest pnpm@latest --force
 
 # --------------------------------


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixes https://github.com/PrestaShop/prestashop-flashlight/issues/48, there is a known issue on cross-compilation issue that was present since the introduction of the Node.js toolkit. <br><br>My previous attempt to port Node.js to Flashlight was overly complicated, and did not relied on the distributions (alpine or debian). That's a pitty because there're aimed precisely for resolving dependencies. <br><br> PrestaShop source code is not yet compatible to the latest 18.x and 20.x branches of Node.js. However we can change that.<br><br> Flashlight now ships also cross-compilation test to avoid such pain at release time in the future.<br><br><br>**Note:** recommended Node.js version set in the prestashop-versions.json file won't be resolved in the produced docker images. The core will be soon get a PR to support Node.js 16-20 on its front-end static assets.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to #48
| How to test?      | Submit any PR, the CI will test it
