### PR TITLE
fix(build): [breaking] only ship Node.js for PrestaShop >= 8.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ get_recommended_nodejs_version() {
   REGEXP_LIST=$(jq -r 'keys_unsorted | .[]' <prestashop-versions.json)
   while IFS= read -r regExp; do
     if [[ $PS_VERSION =~ $regExp ]]; then
-      RECOMMENDED_VERSION=$(jq -r '."'"${regExp}"'".nodejs.recommended' <prestashop-versions.json)
+      RECOMMENDED_VERSION=$(jq -r '."'"${regExp}"'" | if has("nodejs") then .nodejs.recommended else "0.0.0" end' <prestashop-versions.json)
       break;
     fi
   done <<<"$REGEXP_LIST"

--- a/prestashop-versions.json
+++ b/prestashop-versions.json
@@ -3,54 +3,36 @@
     "php": {
       "recommended": "7.1",
       "compatible": ["5.2", "5.3", "5.4", "5.5", "5.6", "7.0", "7.1"]
-    },
-    "nodejs": {
-      "recommended": "0.0.0"
     }
   },
   "^1.7.[0-3]": {
     "php": {
       "recommended": "7.1",
       "compatible": ["5.4", "5.5", "5.6", "7.0", "7.1"]
-    },
-    "nodejs": {
-      "recommended": "10.24.1"
     }
   },
   "^1.7.7.4": {
     "php": {
       "recommended": "7.1",
       "compatible": ["5.6", "7.0", "7.1"]
-    },
-    "nodejs": {
-      "recommended": "10.24.1"
     }
   },
   "^1.7.[5-6]": {
     "php": {
       "recommended": "7.2",
       "compatible": ["5.6", "7.0", "7.1", "7.2"]
-    },
-    "nodejs": {
-      "recommended": "10.24.1"
     }
   },
   "^1.7.7": {
     "php": {
       "recommended": "7.3",
       "compatible": ["7.1", "7.2", "7.3"]
-    },
-    "nodejs": {
-      "recommended": "10.24.1"
     }
   },
   "^1.7.8": {
     "php": {
       "recommended": "7.4",
       "compatible": ["7.1", "7.2", "7.3", "7.4"]
-    },
-    "nodejs": {
-      "recommended": "14.19.0"
     }
   },
   "^8.0": {


### PR DESCRIPTION
@nicosomb I have issues while x-compiling to aarch64 on Alpine. This prevent me from releasing new images of flashlight, which is cumbersome.

If this is not an issue to your use case, I would like to diminish the node.js footprint, as it grabs python3 and an infinite number of dependencies with it.

After this one, I'll have a look at the PrestaShop core, if it's doable to extend Node.js compatibility up to 20.10 LTS.