### PR TITLE
fix(build): the latest tag was misgiven

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,6 +22,38 @@ jobs:
           recursive: true
           dockerfile: "*.Dockerfile"
 
+  docker_dry_build:
+    name: "Docker build dry-run "
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get the latest PrestaShop version
+        id: get_latest_ps_version
+        run: echo "PS_VERSION=curl -s -S -f -L -G $API | jq -r '.tag_name'" >> $GITHUB_OUTPUT
+        env:
+          API: https://api.github.com/repos/prestashop/prestashop/releases/latest
+
+      - name: Should give the "latest" tag for the latest version available
+        run: ./build.sh | grep "prestashop/prestashop-flashlight:latest"
+        env:
+          DRY_RUN: 1
+          PS_VERSION: ${{ steps.get_latest_ps_version.outputs.PS_VERSION }}
+
+      - name: Should not give the "latest" tag to 8.1.2
+        run: ./build.sh | grep -v "prestashop/prestashop-flashlight:latest"
+        env:
+          DRY_RUN: 1
+          PS_VERSION: 8.1.2
+
+      - name: Should not give the "latest" tag if PHP version is not recommended
+        run: ./build.sh | grep -v "prestashop/prestashop-flashlight:latest"
+        env:
+          DRY_RUN: 1
+          PS_VERSION: ${{ steps.get_latest_ps_version.outputs.PS_VERSION }}
+          PHP_VERSION: 7.2
+
   docker_build:
     name: "Docker build: ${{ matrix.os_flavour }} for alpine"
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get the latest PrestaShop version
         id: get_latest_ps_version
-        run: echo "PS_VERSION=curl -s -S -f -L -G $API | jq -r '.tag_name'" >> $GITHUB_OUTPUT
+        run: echo "PS_VERSION=$(curl -s -S -f -L -G $API | jq -r '.tag_name')" >> $GITHUB_OUTPUT
         env:
           API: https://api.github.com/repos/prestashop/prestashop/releases/latest
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,6 +25,7 @@ jobs:
   docker_dry_build:
     name: "Docker build dry-run "
     runs-on: ubuntu-latest
+    needs: [lint_shell, lint_dockerfile]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -60,10 +61,11 @@ jobs:
   docker_build:
     name: "Docker build: ${{ matrix.os_flavour }} for alpine"
     runs-on: ubuntu-latest
+    needs: [docker_dry_build]
     strategy:
+      fail-fast: true
       matrix:
         ps_version: ["1.6.1.24", "1.7.6.9", "1.7.7.8", "1.7.8.11", "8.1.3"]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -96,6 +98,7 @@ jobs:
   docker_build_debian:
     name: "Docker build: 8.1.2 for debian"
     runs-on: ubuntu-latest
+    needs: [docker_dry_build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -109,6 +112,7 @@ jobs:
   docker_build_cross_compile:
     name: "Docker build x-compile for aarch64"
     runs-on: ubuntu-latest
+    needs: docker_build_debian
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
       - name: Get the latest PrestaShop version
         id: get_latest_ps_version
         run: echo "PS_VERSION=curl -s -S -f -L -G $API | jq -r '.tag_name'" >> $GITHUB_OUTPUT

--- a/build.sh
+++ b/build.sh
@@ -8,10 +8,11 @@ declare PS_VERSION;      # -- PrestaShop version, defaults to latest
 declare PHP_VERSION;     # -- PHP version, defaults to recommended version for PrestaShop
 declare OS_FLAVOUR;      # -- either "alpine" (default) or "debian"
 declare SERVER_FLAVOUR;  # -- not implemented, either "nginx" (default) or "apache"
-declare TARGET_PLATFORM;  # -- a comma separated list of target platforms (defaults to "linux/amd64")
+declare TARGET_PLATFORM; # -- a comma separated list of target platforms (defaults to "linux/amd64")
 declare PLATFORM;        # -- alias for $TARGET_PLATFORM
 declare TARGET_IMAGE;    # -- docker image name, defaults to "prestashop/prestashop-flashlight"
 declare PUSH;            # -- set it to "true" if you want to push the resulting image
+declare DRY_RUN;         # -- if used, won't really build the image. Useful to check tags compliance 
 
 # Static configuration
 # --------------------
@@ -136,6 +137,11 @@ fi
 # Build the docker image
 # ----------------------
 CACHE_IMAGE=${TARGET_IMAGES[1]}
+if [ -n "${DRY_RUN}" ]; then
+  docker() {
+    echo docker "$@"
+  }
+fi
 docker pull "$CACHE_IMAGE" 2> /dev/null || true
 docker buildx build \
   --progress=plain \

--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,7 @@ get_target_images() {
   local PHP_VERSION=${3:-};
   local OS_FLAVOUR=${4:-};
   declare RES;
-  if [ "$PS_VERSION" = "$(get_latest_prestashop_version)" ] && [ "$OS_FLAVOUR" = "$DEFAULT_OS" ]; then
+  if [ "$PS_VERSION" = "$(get_latest_prestashop_version)" ] && [ "$OS_FLAVOUR" = "$DEFAULT_OS" ] && [ "$PHP_VERSION" = "$(get_recommended_php_version "$PS_VERSION")" ]; then
     RES="-t ${DEFAULT_DOCKER_IMAGE}:latest";
   fi
   if [ "$OS_FLAVOUR" = "$DEFAULT_OS" ]; then


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | the latest tag only apply to the latest PS_VERSION and the recommended PHP_VERSION
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #61
| Sponsor company   | Mikatux corp
| How to test?      | `DRY_RUN=1 PS_VERSION=8.1.3 PHP_VERSION=7.2 ./build.sh \| grep -v ':latest'`

