### PR TITLE
fea(release.sh): automates compatible & recommended php versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ sonar-project.properties
 
 PrestaShop/
 vendor/
+.prestashop-tags
+.prestashop-minor-tags

--- a/release.sh
+++ b/release.sh
@@ -57,9 +57,7 @@ done < "$PRESTASHOP_MINOR_TAGS"
 
 # Compatible PHP for every minor tag (alpine only)
 while IFS= read -r PS_VERSION; do
-  echo "$PS_VERSION:"
   while IFS= read -r PHP_VERSION; do
-    echo "--> $PHP_VERSION"
-    publish --field ps_version="$PS_VERSION" --filed php_version="$PHP_VERSION"
+    publish --field ps_version="$PS_VERSION" --field php_version="$PHP_VERSION"
   done <<<"$(get_compatible_php_version "$PS_VERSION")"
 done < "$PRESTASHOP_MINOR_TAGS"

--- a/release.sh
+++ b/release.sh
@@ -1,27 +1,65 @@
 #!/bin/sh
+set -eu
+PRESTASHOP_TAGS=.prestashop-tags
+PRESTASHOP_MINOR_TAGS=.prestashop-minor-tags
+
+get_prestashop_tags() {
+  git ls-remote --tags git@github.com:PrestaShop/PrestaShop.git \
+  | cut -f2 \
+  | grep -Ev '\/1.5|\/1.6.0|beta|rc|RC|\^' \
+  | cut -d '/' -f3 \
+  | sort -r -V > "$PRESTASHOP_TAGS"
+}
+
+get_prestashop_minor_tags() {
+  printf "" > "$PRESTASHOP_MINOR_TAGS"
+  while IFS= read -r version; do
+    major_minor=$(echo "$version" | cut -d. -f1-2)
+    major_minor_patch=$(echo "$version" | cut -d. -f1-3)
+    criteria=$major_minor
+    # shellcheck disable=SC3010
+    [[ "$major_minor" == 1* ]] && criteria=$major_minor_patch
+    if ! grep -q "^$criteria" "$PRESTASHOP_MINOR_TAGS"; then
+      echo "$version" >> "$PRESTASHOP_MINOR_TAGS"
+    fi
+  done < "$PRESTASHOP_TAGS"
+}
+
+get_compatible_php_version() {
+  local PS_VERSION=$1;
+  REGEXP_LIST=$(jq -r 'keys_unsorted | .[]' <prestashop-versions.json)
+  while IFS= read -r regExp; do
+    if [[ $PS_VERSION =~ $regExp ]]; then
+      jq -r '."'"${regExp}"'".php.compatible[]' <prestashop-versions.json
+      break;
+    fi
+  done <<<"$REGEXP_LIST"
+}
+
 publish() {
   gh workflow run docker-publish.yml \
   --repo prestashop/prestashop-flashlight \
   --field target_platforms=linux/amd64,linux/arm64 "$@"
 }
 
+get_prestashop_tags
+get_prestashop_minor_tags
+
+# Latest
 publish --field ps_version=latest
-publish --field ps_version=8.1.3
-publish --field ps_version=1.7.8.11
-publish --field ps_version=1.6.1.24
+publish --field ps_version=latest --field os_flavour=debian
 
-publish --field os_flavour=debian --field ps_version=latest
-publish --field os_flavour=debian --field ps_version=1.7.8.11
-publish --field os_flavour=debian --field ps_version=1.6.1.24
+# Recommended PHP for every minor tag
+while IFS= read -r PS_VERSION; do
+  publish --field ps_version="$PS_VERSION"
+  publish --field ps_version="$PS_VERSION" --field os_flavour=debian
+done < "$PRESTASHOP_MINOR_TAGS"
 
-# Minor versions from 1.7
-publish --field ps_version=1.7.0.6
-publish --field ps_version=1.7.1.2
-publish --field ps_version=1.7.2.5
-publish --field ps_version=1.7.3.4
-publish --field ps_version=1.7.4.4
-publish --field ps_version=1.7.5.2
-publish --field ps_version=1.7.6.9
-publish --field ps_version=1.7.7.8
-publish --field ps_version=1.7.8.9
-publish --field ps_version=8.0.5
+# Compatible PHP for every minor tag (alpine only)
+while IFS= read -r PS_VERSION; do
+  echo "$PS_VERSION:"
+  while IFS= read -r PHP_VERSION; do
+    echo "--> $PHP_VERSION"
+    publish --field ps_version="$PS_VERSION" --filed php_version="$PHP_VERSION"
+  done <<<"$(get_compatible_php_version "$PS_VERSION")"
+done < "$PRESTASHOP_MINOR_TAGS"

--- a/release.sh
+++ b/release.sh
@@ -26,14 +26,16 @@ get_prestashop_minor_tags() {
 }
 
 get_compatible_php_version() {
-  local PS_VERSION=$1;
   REGEXP_LIST=$(jq -r 'keys_unsorted | .[]' <prestashop-versions.json)
   while IFS= read -r regExp; do
-    if [[ $PS_VERSION =~ $regExp ]]; then
+    # shellcheck disable=SC3010
+    if [[ $1 =~ $regExp ]]; then
       jq -r '."'"${regExp}"'".php.compatible[]' <prestashop-versions.json
       break;
     fi
-  done <<<"$REGEXP_LIST"
+  done <<EOF
+$REGEXP_LIST
+EOF
 }
 
 publish() {
@@ -59,5 +61,7 @@ done < "$PRESTASHOP_MINOR_TAGS"
 while IFS= read -r PS_VERSION; do
   while IFS= read -r PHP_VERSION; do
     publish --field ps_version="$PS_VERSION" --field php_version="$PHP_VERSION"
-  done <<<"$(get_compatible_php_version "$PS_VERSION")"
+  done <<EOF
+$(get_compatible_php_version "$PS_VERSION")
+EOF
 done < "$PRESTASHOP_MINOR_TAGS"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Automates the automated build process: now guess all the tags and image combination we wish to build every time flashlight is updated. Also build images for major.minor versions of PrestaShop from 7 to 8+, and major.minor.patch for 1.6. Build images with recommended AND compatible versions of PHP.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #60
| How to test?      | ./release.sh
