### PR TITLE
minor(env): test prestashop-flashlight with the latest release

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ps_version: ["1.6.1.24", "1.7.6.9", "1.7.7.8", "1.7.8.11", "8.1.3"]
+        ps_version: ["1.6.1.24", "1.7.6.9", "1.7.7.8", "1.7.8.11", "8.1.4"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | PrestaShop 8.1.4 has just been released: https://github.com/PrestaShop/PrestaShop/releases/tag/8.1.4.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
