### PR TITLE
fix(ci): build docker images with an ARM64 arch

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint_shell:
     name: "Lint: shell"
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +16,7 @@ jobs:
 
   lint_dockerfile:
     name: "Lint: dockerfile"
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
 
   docker_dry_build:
     name: "Docker build dry-run "
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 5
     needs: [lint_shell, lint_dockerfile]
     steps:
@@ -64,7 +64,7 @@ jobs:
 
   docker_build:
     name: "Docker build: ${{ matrix.os_flavour }} for alpine"
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 15
     needs: [docker_dry_build]
     strategy:
@@ -102,7 +102,7 @@ jobs:
 
   docker_build_debian:
     name: "Docker build: 8.1.2 for debian"
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 15
     needs: [docker_dry_build]
     steps:
@@ -117,7 +117,7 @@ jobs:
 
   docker_build_nightly:
     name: "Docker build: PS nightly"
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -130,7 +130,7 @@ jobs:
 
   docker_build_cross_compile:
     name: "Docker build x-compile for aarch64"
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 20
     needs: docker_build_debian
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint_shell:
     name: "Lint: shell"
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +16,7 @@ jobs:
 
   lint_dockerfile:
     name: "Lint: dockerfile"
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
 
   docker_dry_build:
     name: "Docker build dry-run "
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [lint_shell, lint_dockerfile]
     steps:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Might get better performances at building PrestaShop Flashlight in the CI env. See: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Might fix #83
| Sponsor company   | PrestaShop
| How to test?      | Lets see the runners of this PR
