### PR TITLE
fix(examples): Missing PS_DOMAIN on ngrok

### DIFF
--- a/assets/run.sh
+++ b/assets/run.sh
@@ -31,15 +31,15 @@ run_user () {
 }
 
 if [ ! -f $INIT_LOCK ] || [ "$INIT_ON_RESTART" = "true" ]; then
-  if [ -z "${PS_DOMAIN:-}" ] && [ -z "${NGROK_TUNNEL_AUTO_DETECT:-}" ]; then
+  if [ -n "${PS_DOMAIN:-}" ]; then
+    case "$PS_DOMAIN" in
+      http*) echo "PS_DOMAIN is not expected to be an URI"; sleep 3; exit 2 ;;
+    esac
+  elif [ -z "${NGROK_TUNNEL_AUTO_DETECT:-}" ]; then
     echo "Missing PS_DOMAIN or NGROK_TUNNEL_AUTO_DETECT. Exiting"
     sleep 3
     exit 2
   fi
-
-  case "$PS_DOMAIN" in
-    http*) echo "PS_DOMAIN is not expected to be an URI"; sleep 3; exit 2 ;;
-  esac
 
   # Check if a tunnel autodetection mechanism should be involved
   if [ -n "${NGROK_TUNNEL_AUTO_DETECT+x}" ]; then


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix ngrock example with - PS_DOMAIN=localhost:8000
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | docker compose up -d

![image](https://github.com/PrestaShop/prestashop-flashlight/assets/35234721/f57651be-af79-4a7f-8acf-db6fb41fa89e)
