### PR TITLE
fix(alpine): revert back make to alpine images

### DIFF
--- a/assets/alpine-base-install.sh
+++ b/assets/alpine-base-install.sh
@@ -52,5 +52,5 @@ fi
 
 # Cleanup dev packages, keep libraries
 apk --no-cache del -U build-base autoconf gcc g++ libgcc nginx-vim mariadb xz-dev musl-dev linux-headers freetype-dev zlib-dev libjpeg-turbo-dev libpng-dev oniguruma-dev libzip-dev icu-dev libmcrypt-dev libxml2-dev
-apk --no-cache add -U mariadb-client freetype zlib libjpeg-turbo libpng oniguruma libzip icu libmcrypt libxml2
+apk --no-cache add -U make mariadb-client freetype zlib libjpeg-turbo libpng oniguruma libzip icu libmcrypt libxml2
 rm -rf /var/cache/apk/*


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Make is really useful when it comes to orchestrate build & test commands for PrestaShop modules. It was unexpectedly removed from flashlight last week.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Sponsor company   | PrestaShop
| How to test?      | `docker run -it --rm --entrypoint sh prestashop/prestashop-flashlight:8.1.5-alpine -c 'which make'`
