### PR TITLE
fix(build): hanging mysqld startup and connectivity check

### DIFF
--- a/assets/hydrate.sh
+++ b/assets/hydrate.sh
@@ -25,14 +25,15 @@ mkdir -p /run/mysqld /var/lib/mysql/;
 mysql_install_db \
   --user=root \
   --ldata=/var/lib/mysql/ > /dev/null;
-nohup mysqld --user=root --skip-networking=0 --port=${DB_PORT} --socket=${DB_SOCKET} &
-while [ ! -S ${DB_SOCKET} ]; do sleep 0.1; done
-while ! nc -z localhost ${DB_PORT}; do sleep 0.1; done
+nohup mysqld --user=root --bind-address=${DB_SERVER} --port=${DB_PORT} --socket=${DB_SOCKET} &
+
+while [ ! -S "$DB_SOCKET" ]; do sleep 0.1; done
+while ! nc -z "$DB_SERVER" "$DB_PORT"; do sleep 0.1; done
 echo "✅ MySQL started"
 
 # 3. Setup the root password, add a PrestaShop database
-mysql --user=root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '${DB_PASSWD}';"
-mysql --user=root --password=${DB_PASSWD} -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME}";
+mysql --user=root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '$DB_PASSWD';"
+mysql --user=root --password="$DB_PASSWD" -e "CREATE DATABASE IF NOT EXISTS $DB_NAME";
 
 # 4. Connectivity test (both the unix socket file and DB_SERVER:DB_PORT)
 php -r "new PDO('mysql:unix_socket=""$DB_SOCKET"";dbname=""$DB_NAME""', '""$DB_USER""', '""$DB_PASSWD""');"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | As you might noticed, nightly builds were stopping on error, due to timeout. I could not reproduce the issue on an arm64 setup, so did I tried on an amd64 one. I could reproduce and identify the tiny bits.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `PS_VERSION=nightly ./build.sh`
