### PR TITLE
Review healthchecks for mariadb:lts

### DIFF
--- a/examples/auto-install-modules/docker-compose.yml
+++ b/examples/auto-install-modules/docker-compose.yml
@@ -18,15 +18,7 @@ services:
   mysql:
     image: mariadb:lts
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "--host=localhost",
-          "--user=root",
-          "--password=prestashop",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/examples/basic-example/docker-compose.yml
+++ b/examples/basic-example/docker-compose.yml
@@ -16,15 +16,7 @@ services:
   mysql:
     image: mariadb:lts
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "--host=localhost",
-          "--user=root",
-          "--password=prestashop",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/examples/cloudflared-tunnel/docker-compose.yml
+++ b/examples/cloudflared-tunnel/docker-compose.yml
@@ -16,15 +16,7 @@ services:
   mysql:
     image: mariadb:lts
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "--host=localhost",
-          "--user=root",
-          "--password=prestashop",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/examples/develop-a-module/docker-compose.yml
+++ b/examples/develop-a-module/docker-compose.yml
@@ -19,15 +19,7 @@ services:
   mysql:
     image: mariadb:lts
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "--host=localhost",
-          "--user=root",
-          "--password=prestashop",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/examples/develop-prestashop/docker-compose.yml
+++ b/examples/develop-prestashop/docker-compose.yml
@@ -18,15 +18,7 @@ services:
   mysql:
     image: mariadb:lts
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "--host=localhost",
-          "--user=root",
-          "--password=prestashop",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/examples/ngrok-tunnel/docker-compose.yml
+++ b/examples/ngrok-tunnel/docker-compose.yml
@@ -1,4 +1,4 @@
-name: flashlight-ngrok-tunnel
+name: tunnel1
 services:
   prestashop:
     image: prestashop/prestashop-flashlight:latest
@@ -15,15 +15,7 @@ services:
   mysql:
     image: mariadb:lts
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "--host=localhost",
-          "--user=root",
-          "--password=prestashop",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/examples/nightly-example/docker-compose.yml
+++ b/examples/nightly-example/docker-compose.yml
@@ -14,15 +14,7 @@ services:
   mysql:
     image: mariadb:lts
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "--host=localhost",
-          "--user=root",
-          "--password=prestashop",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/examples/with-init-scripts/docker-compose.yml
+++ b/examples/with-init-scripts/docker-compose.yml
@@ -18,15 +18,7 @@ services:
   mysql:
     image: mariadb:lts
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "--host=localhost",
-          "--user=root",
-          "--password=prestashop",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/examples/with-post-scripts/docker-compose.yml
+++ b/examples/with-post-scripts/docker-compose.yml
@@ -17,15 +17,7 @@ services:
   mysql:
     image: mariadb:lts
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "--host=localhost",
-          "--user=root",
-          "--password=prestashop",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/examples/xdebug-prestashop/docker-compose.yml
+++ b/examples/xdebug-prestashop/docker-compose.yml
@@ -18,15 +18,7 @@ services:
   mysql:
     image: mariadb:lts
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "--host=localhost",
-          "--user=root",
-          "--password=prestashop",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 10s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Mariadb LTS recently changed, and our healthcheck assumptions in the docker-compose examples are now wrong. This adjustment simplifies and restore the way Flashlight will wait Mariadb to be healthy & running before starting.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #110
| How to test?      | `cd ./examples/basic-example && docker-compose up`
