### PR TITLE
feat(build): add PHP<7.1 support to PS 1.6

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -109,6 +109,10 @@ jobs:
     name: "Docker build: PrestaShop with PHP 5.6"
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: true
+      matrix:
+        os_version: ["alpine", "debian"]
     needs: [docker_dry_build]
     steps:
       - name: Checkout repository

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -105,6 +105,26 @@ jobs:
         env:
           DOCKER_IMAGE: prestashop/prestashop-flashlight:${{ matrix.ps_version }}
 
+  docker_build_old_php:
+    name: "Docker build: PrestaShop with PHP 5.6"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [docker_dry_build]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Call the docker build chain
+        run: ./build.sh
+        env:
+          PS_VERSION: 1.6.1.24
+          PHP_VERSION: 5.6
+
+      - name: Test the image with a dry run
+        run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' $DOCKER_IMAGE
+        env:
+          DOCKER_IMAGE: prestashop/prestashop-flashlight:1.6.1.24-5.6
+
   docker_build_debian:
     name: "Docker build: PS ${{ matrix.ps_version }} for debian"
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -123,11 +123,12 @@ jobs:
         env:
           PS_VERSION: 1.6.1.24
           PHP_VERSION: 5.6
+          OS_VERSION: ${{ matrix.os_version }}
 
       - name: Test the image with a dry run
         run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' $DOCKER_IMAGE
         env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:1.6.1.24-5.6
+          DOCKER_IMAGE: prestashop/prestashop-flashlight:$PS_VERSION-$OS_VERSION
 
   docker_build_debian:
     name: "Docker build: PS ${{ matrix.ps_version }} for debian"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Test the image with a dry run
         run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' $DOCKER_IMAGE
         env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:$PS_VERSION-$OS_VERSION
+          DOCKER_IMAGE: prestashop/prestashop-flashlight:1.6.1.24-${{ matrix.os_version }}
 
   docker_build_debian:
     name: "Docker build: PS ${{ matrix.ps_version }} for debian"

--- a/assets/alpine-base-install.sh
+++ b/assets/alpine-base-install.sh
@@ -6,7 +6,7 @@ apk --no-cache add -U \
   bash less vim geoip git tzdata zip curl jq autoconf \
   nginx nginx-mod-http-headers-more nginx-mod-http-geoip \
   nginx-mod-stream nginx-mod-stream-geoip ca-certificates \
-  gnu-libiconv php-common mariadb-client sudo libjpeg libxml2 \
+  php-common php-iconv php-gd mariadb-client sudo libjpeg libxml2 \
   build-base linux-headers freetype-dev zlib-dev libjpeg-turbo-dev \
   libpng-dev oniguruma-dev libzip-dev icu-dev libmcrypt-dev libxml2-dev \
   openssh-client
@@ -26,27 +26,35 @@ curl -s https://getcomposer.org/installer | php
 mv composer.phar /usr/bin/composer
 
 # Install PrestaShop tools required by prestashop coding-standards
-composer require nikic/php-parser --working-dir=/var/opt
+composer require nikic/php-parser --working-dir=/var/opt || true
 
 # Install phpunit
 PHPUNIT_VERSION=$(jq -r '."'"${PHP_SHORT_VERSION}"'".phpunit' < /tmp/php-flavours.json)
-wget -q -O /usr/bin/phpunit "https://phar.phpunit.de/phpunit-${PHPUNIT_VERSION}.phar"
-chmod +x /usr/bin/phpunit
+if [ "$PHPUNIT_VERSION" != "null" ]; then
+  wget -q -O /usr/bin/phpunit "https://phar.phpunit.de/phpunit-${PHPUNIT_VERSION}.phar"
+  chmod +x /usr/bin/phpunit
+fi
 
 # Install phpstan
 PHPSTAN_VERSION=$(jq -r '."'"${PHP_SHORT_VERSION}"'".phpstan' < /tmp/php-flavours.json)
-wget -q -O /usr/bin/phpstan "https://github.com/phpstan/phpstan/raw/${PHPSTAN_VERSION}/phpstan.phar"
-chmod a+x /usr/bin/phpstan
+if [ "$PHPSTAN_VERSION" != "null" ]; then
+  wget -q -O /usr/bin/phpstan "https://github.com/phpstan/phpstan/raw/${PHPSTAN_VERSION}/phpstan.phar"
+  chmod a+x /usr/bin/phpstan
+fi
 
 # Install php-cs-fixer
 PHP_CS_FIXER=$(jq -r '."'"${PHP_SHORT_VERSION}"'".php_cs_fixer' < /tmp/php-flavours.json)
-wget -q -O /usr/bin/php-cs-fixer "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/${PHP_CS_FIXER}/php-cs-fixer.phar"
-chmod a+x /usr/bin/php-cs-fixer
+if [ "$PHP_CS_FIXER" != "null" ]; then
+  wget -q -O /usr/bin/php-cs-fixer "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/${PHP_CS_FIXER}/php-cs-fixer.phar"
+  chmod a+x /usr/bin/php-cs-fixer
+fi
 
 # Install xdebug
 PHP_XDEBUG=$(jq -r '."'"${PHP_SHORT_VERSION}"'".xdebug' < /tmp/php-flavours.json)
-pecl install "xdebug-$PHP_XDEBUG"
-docker-php-ext-enable xdebug
+if [ "$PHP_XDEBUG" != "null" ]; then
+  pecl install "xdebug-$PHP_XDEBUG"
+  docker-php-ext-enable xdebug
+fi
 
 # Install Node.js (shipping yarn and npm) and pnpm
 if [ "0.0.0" != "$NODE_VERSION" ]; then

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -64,23 +64,31 @@ composer require nikic/php-parser --working-dir=/var/opt
 
 # Install phpunit
 PHPUNIT_VERSION=$(jq -r '."'"${PHP_SHORT_VERSION}"'".phpunit' < /tmp/php-flavours.json)
-wget -q -O /usr/bin/phpunit "https://phar.phpunit.de/phpunit-${PHPUNIT_VERSION}.phar"
-chmod +x /usr/bin/phpunit
+if [ "$PHPUNIT_VERSION" != "null" ]; then
+  wget -q -O /usr/bin/phpunit "https://phar.phpunit.de/phpunit-${PHPUNIT_VERSION}.phar"
+  chmod +x /usr/bin/phpunit
+fi
 
 # Install phpstan
 PHPSTAN_VERSION=$(jq -r '."'"${PHP_SHORT_VERSION}"'".phpstan' < /tmp/php-flavours.json)
-wget -q -O /usr/bin/phpstan "https://github.com/phpstan/phpstan/raw/${PHPSTAN_VERSION}/phpstan.phar"
-chmod a+x /usr/bin/phpstan
+if [ "$PHPSTAN_VERSION" != "null" ]; then
+  wget -q -O /usr/bin/phpstan "https://github.com/phpstan/phpstan/raw/${PHPSTAN_VERSION}/phpstan.phar"
+  chmod a+x /usr/bin/phpstan
+fi
 
 # Install php-cs-fixer
 PHP_CS_FIXER=$(jq -r '."'"${PHP_SHORT_VERSION}"'".php_cs_fixer' < /tmp/php-flavours.json)
-wget -q -O /usr/bin/php-cs-fixer "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/${PHP_CS_FIXER}/php-cs-fixer.phar"
-chmod a+x /usr/bin/php-cs-fixer
+if [ "$PHP_CS_FIXER" != "null" ]; then
+  wget -q -O /usr/bin/php-cs-fixer "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/${PHP_CS_FIXER}/php-cs-fixer.phar"
+  chmod a+x /usr/bin/php-cs-fixer
+fi
 
 # Install xdebug
 PHP_XDEBUG=$(jq -r '."'"${PHP_SHORT_VERSION}"'".xdebug' < /tmp/php-flavours.json)
-pecl install "xdebug-${PHP_XDEBUG}"
-docker-php-ext-enable xdebug
+if [ "$PHP_XDEBUG" != "null" ]; then
+  pecl install "xdebug-$PHP_XDEBUG"
+  docker-php-ext-enable xdebug
+fi
 
 # Install Node.js (shipping yarn and npm) and pnpm
 if [ "0.0.0" != "$NODE_VERSION" ]; then

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -v
 set -eu
 
 # Disable man pages and documentation
@@ -15,6 +15,16 @@ rm -rf /usr/share/doc \
 # Get debian version and codename
 # shellcheck disable=SC1091
 . /etc/os-release
+if [ "$VERSION_ID" = 9 ]; then
+  export VERSION_CODENAME="stretch";
+fi
+
+# https://unix.stackexchange.com/a/743874
+if [ "$VERSION_CODENAME" = "stretch"  ]; then
+  sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+  sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
+  sed -i s/stretch-updates/stretch/g /etc/apt/sources.list
+fi
 
 # Update certificates and install base deps
 export DEBIAN_FRONTEND=noninteractive
@@ -22,12 +32,14 @@ curl -s -L -H "Content-Type: application/octet-stream" \
   --data-binary "@/etc/apt/trusted.gpg.d/php.gpg" \
   "https://packages.sury.org/php/apt.gpg"
 apt-get update
-apt-get install --no-install-recommends -qqy ca-certificates
+apt-get install --no-install-recommends -qqy apt-transport-https ca-certificates
 apt-get install --no-install-recommends -o Dpkg::Options::="--force-confold" -qqy bash less vim git sudo mariadb-client \
   tzdata zip unzip curl wget make jq netcat-traditional build-essential \
   lsb-release libgnutls30 gnupg libiconv-hook1 libonig-dev nginx libnginx-mod-http-headers-more-filter libnginx-mod-http-geoip \
   libnginx-mod-http-geoip libnginx-mod-stream openssh-client;
-echo "deb [trusted=yes] https://packages.sury.org/php/ $VERSION_CODENAME main" > /etc/apt/sources.list.d/php.list
+if [ "$VERSION_CODENAME" != "stretch"  ]; then
+  echo "deb [trusted=yes] https://packages.sury.org/php/ $VERSION_CODENAME main" > /etc/apt/sources.list.d/php.list
+fi
 rm /etc/apt/preferences.d/no-debian-php
 apt-get update
 LIB_FREETYPE_DEV=$(apt-cache search '^libfreetype[0-9]+-dev$' | awk 'NR==1{print $1}')

--- a/assets/hydrate.sh
+++ b/assets/hydrate.sh
@@ -11,7 +11,7 @@ export PS_DOMAIN="localhost:80" \
   DB_SERVER=127.0.0.1 \
   DB_PORT=3306 \
   DB_NAME=prestashop \
-  DB_USER=root \
+  DB_USER=prestashop \
   DB_PASSWD=prestashop \
   ADMIN_MAIL=admin@prestashop.com \
   ADMIN_PASSWD=prestashop \
@@ -25,15 +25,16 @@ mkdir -p /run/mysqld /var/lib/mysql/;
 mysql_install_db \
   --user=root \
   --ldata=/var/lib/mysql/ > /dev/null;
-nohup mysqld --user=root --bind-address=${DB_SERVER} --port=${DB_PORT} --socket=${DB_SOCKET} &
+nohup mysqld --user=root --bind-address="$DB_SERVER" --port="$DB_PORT" --socket="$DB_SOCKET" &
 
 while [ ! -S "$DB_SOCKET" ]; do sleep 0.1; done
 while ! nc -z "$DB_SERVER" "$DB_PORT"; do sleep 0.1; done
 echo "✅ MySQL started"
 
 # 3. Setup the root password, add a PrestaShop database
-mysql --user=root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '$DB_PASSWD';"
 mysql --user=root --password="$DB_PASSWD" -e "CREATE DATABASE IF NOT EXISTS $DB_NAME";
+mysql --user=root --password="$DB_PASSWD" -e "CREATE USER '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASSWD';"
+mysql --user=root --password="$DB_PASSWD" -e "GRANT ALL PRIVILEGES ON *.* TO '$DB_USER'@'localhost'; FLUSH PRIVILEGES;"
 
 # 4. Connectivity test (both the unix socket file and DB_SERVER:DB_PORT)
 php -r "new PDO('mysql:unix_socket=""$DB_SOCKET"";dbname=""$DB_NAME""', '""$DB_USER""', '""$DB_PASSWD""');"

--- a/assets/hydrate.sh
+++ b/assets/hydrate.sh
@@ -32,9 +32,9 @@ while ! nc -z "$DB_SERVER" "$DB_PORT"; do sleep 0.1; done
 echo "✅ MySQL started"
 
 # 3. Setup the root password, add a PrestaShop database
-mysql --user=root --password="$DB_PASSWD" -e "CREATE DATABASE IF NOT EXISTS $DB_NAME";
-mysql --user=root --password="$DB_PASSWD" -e "CREATE USER '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASSWD';"
-mysql --user=root --password="$DB_PASSWD" -e "GRANT ALL PRIVILEGES ON *.* TO '$DB_USER'@'localhost'; FLUSH PRIVILEGES;"
+mysql --user=root -e "CREATE DATABASE IF NOT EXISTS $DB_NAME";
+mysql --user=root -e "CREATE USER '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASSWD';";
+mysql --user=root -e "GRANT ALL PRIVILEGES ON *.* TO '$DB_USER'@'localhost'; FLUSH PRIVILEGES;"
 
 # 4. Connectivity test (both the unix socket file and DB_SERVER:DB_PORT)
 php -r "new PDO('mysql:unix_socket=""$DB_SOCKET"";dbname=""$DB_NAME""', '""$DB_USER""', '""$DB_PASSWD""');"

--- a/assets/php-configuration.sh
+++ b/assets/php-configuration.sh
@@ -17,7 +17,7 @@ error() {
 PS_PHP_EXT="gd pdo_mysql zip intl fileinfo mbstring simplexml soap bcmath"
 PHP_GD_CONFIG="--with-jpeg --with-freetype";
 
-if [ "7.1" = "$PHP_VERSION" ]; then
+if [ "5.5" = "$PHP_VERSION" ] || [ "5.6" = "$PHP_VERSION" ] || [ "7.0" = "$PHP_VERSION" ] || [ "7.1" = "$PHP_VERSION" ]; then
   PS_PHP_EXT="$PS_PHP_EXT mcrypt";
   PHP_GD_CONFIG="--with-gd --with-jpeg --with-jpeg-dir --with-zlib-dir --with-freetype-dir";
 elif [ "7.2" = "$PHP_VERSION" ] || [ "7.3" = "$PHP_VERSION" ]; then

--- a/build.sh
+++ b/build.sh
@@ -172,7 +172,7 @@ docker buildx build \
   --label org.opencontainers.image.title="PrestaShop Flashlight" \
   --label org.opencontainers.image.description="PrestaShop Flashlight testing utility" \
   --label org.opencontainers.image.source=https://github.com/PrestaShop/prestashop-flashlight \
-  --label org.opencontainers.image.url=https://github.com/PrestaShop/prestashop-flashlight \
+  --label org.opencontainers.image.url=https://hub.docker.com/r/prestashop/prestashop-flashlight \
   --label org.opencontainers.image.licenses=MIT \
   --label org.opencontainers.image.created="$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")" \
   "${TARGET_IMAGES[@]}" \

--- a/php-flavours.json
+++ b/php-flavours.json
@@ -1,4 +1,20 @@
 {
+  "5.5": {
+    "alpine": "5.5-fpm-alpine",
+    "debian": "5.5-fpm"
+  },
+  "5.6": {
+    "alpine": "5.6-fpm-alpine",
+    "debian": "5.6-fpm-stretch"
+  },
+  "7.0": {
+    "alpine": "7.0-fpm-alpine",
+    "debian": "7.0-fpm-jessie",
+    "phpunit": "6.5.14",
+    "php_cs_fixer": "v2.19.3",
+    "phpstan": "0.9.3",
+    "xdebug": "2.7.2"
+  },
   "7.1": {
     "alpine": "7.1-fpm-alpine",
     "debian": "7.1-fpm-buster",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | My colleague needs a testing Flashlight instance for PS 1.6 with PHP 5.6. This build cannot be currently performed yet.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Sponsor company   | PrestaShop
| How to test?      | `PS_VERSION=1.6.1.21 PHP_VERSION=5.6 ./build.sh`


* [x] Alpine support
* [x] Debian support
