### PR TITLE
absolute path for bin/console when auto installing module

### DIFF
--- a/assets/run.sh
+++ b/assets/run.sh
@@ -190,9 +190,9 @@ if [ ! -f $MODULES_INSTALLED_LOCK ] || [ "$INSTALL_MODULES_ON_RESTART" = "true" 
         rm -rf "/var/www/html/modules/${module:-something-at-least}"
         run_user unzip -qq "$file" -d /var/www/html/modules
         if [ "$ON_INSTALL_MODULES_FAILURE" = "continue" ]; then
-          (run_user php -d memory_limit=-1 bin/console prestashop:module --no-interaction install "$module") || { echo "x module installation failed. Skipping."; }
+          (run_user php -d memory_limit=-1 "$PS_FOLDER/bin/console" prestashop:module --no-interaction install "$module") || { echo "x module installation failed. Skipping."; }
         else
-          (run_user php -d memory_limit=-1 bin/console prestashop:module --no-interaction install "$module") || { echo "x module installation failed. Sleep and exit."; sleep 10; exit 6; }
+          (run_user php -d memory_limit=-1 "$PS_FOLDER/bin/console" prestashop:module --no-interaction install "$module") || { echo "x module installation failed. Sleep and exit."; sleep 10; exit 6; }
         fi
       done;
     else


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | set absolute path for bin/console call when auto installing module
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{https://github.com/PrestaShop/prestashop-flashlight/issues/118}
| Sponsor company   | PrestaShop
| How to test?      | Run the auto install module example
