### PR TITLE
fix(build): Debian build for PHP 5.6

### DIFF
--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -37,7 +37,7 @@ apt-get install --no-install-recommends -o Dpkg::Options::="--force-confold" -qq
   tzdata zip unzip curl wget make jq netcat-traditional build-essential \
   lsb-release libgnutls30 gnupg libiconv-hook1 libonig-dev nginx libnginx-mod-http-headers-more-filter libnginx-mod-http-geoip \
   libnginx-mod-http-geoip libnginx-mod-stream openssh-client;
-if [ "$VERSION_CODENAME" != "stretch"  ]; then
+if [ "$VERSION_CODENAME" != "stretch" ] && [ "$VERSION_CODENAME" != "buster" ]; then
   echo "deb [trusted=yes] https://packages.sury.org/php/ $VERSION_CODENAME main" > /etc/apt/sources.list.d/php.list
 fi
 rm /etc/apt/preferences.d/no-debian-php

--- a/assets/run.sh
+++ b/assets/run.sh
@@ -213,7 +213,7 @@ if [ -d "$INIT_SCRIPTS_DIR" ]; then
       if [ -x "$1" ] && [ "$ON_INIT_SCRIPT_FAILURE" = "continue" ]; then
         printf "\n--> Running $1...\n"
         (sudo -E -g '"$INIT_SCRIPTS_USER"' -u '"$INIT_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Skipping."; }
-      else if [ -x "$1" ]; then
+      elif [ -x "$1" ]; then
         printf "\n--> Running $1...\n"
         (sudo -E -g '"$INIT_SCRIPTS_USER"' -u '"$INIT_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 7; }
       fi
@@ -250,7 +250,7 @@ if [ -d "$POST_SCRIPTS_DIR" ]; then
       if  [ -x "$1" ] && [ "$ON_POST_SCRIPT_FAILURE" = "continue" ]; then
         printf "\n--> Running $1...\n"
         (sudo -E -u '"$POST_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Skipping."; }
-      else if [ -x "$1" ]; then
+      elif [ -x "$1" ]; then
         (sudo -E -u '"$POST_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 8; }
       fi
     ' sh | awk 'BEGIN{RS="\n";ORS="\n  "}1';

--- a/assets/run.sh
+++ b/assets/run.sh
@@ -210,9 +210,9 @@ if [ -d "$INIT_SCRIPTS_DIR" ]; then
     printf "* Running init-script(s)..."
     # shellcheck disable=SC2016
     find "$INIT_SCRIPTS_DIR" -maxdepth 1 -type f -print0 | sort -z | xargs -0 -n1 sh -c '
-    if  [ -x "$1" ]; then
+      if [ -x "$1" ]; then
         printf "\n--> Running $1...\n"
-        (sudo -E -u '"$INIT_SCRIPTS_DIR"' -- $1) || {
+        (sudo -E -u '"$INIT_SCRIPTS_USER"' -- $1) || {
           if [ "$ON_INIT_SCRIPT_FAILURE" = "continue" ]; then
             echo "x $1 execution failed. Skipping.";
           else 

--- a/assets/run.sh
+++ b/assets/run.sh
@@ -209,7 +209,7 @@ if [ -d "$INIT_SCRIPTS_DIR" ]; then
   if [ ! -f $INIT_SCRIPTS_LOCK ] || [ "$INIT_SCRIPTS_ON_RESTART" = "true" ]; then
     printf "* Running init-script(s)..."
     # shellcheck disable=SC2016
-    find "$INIT_SCRIPTS_DIR" -maxdepth 1 -executable -type f -print0 | sort -z | xargs -0 -n1 sh -c '
+    find "$POST_SCRIPTS_DIR" -maxdepth 1 -type f -print0 | xargs -0 -n1 -I{} sh -c 'if [ -x "{}" ]; then echo "{}"; fi' | sort -z | xargs -0 -n1 sh -c '
       printf "\n--> Running $1...\n"
       if [ "$ON_INIT_SCRIPT_FAILURE" = "continue" ]; then
         (sudo -E -g '"$INIT_SCRIPTS_USER"' -u '"$INIT_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Skipping."; }
@@ -245,7 +245,8 @@ if [ -d "$POST_SCRIPTS_DIR" ]; then
   if [ ! -f $POST_SCRIPTS_LOCK ] || [ "$POST_SCRIPTS_ON_RESTART" = "true" ]; then
     printf "* Running post-script(s)..."
     # shellcheck disable=SC2016
-    find "$POST_SCRIPTS_DIR" -maxdepth 1 -executable -type f -print0 | sort -z | xargs -0 -n1 sh -c '
+    find "$POST_SCRIPTS_DIR" -maxdepth 1 -type f -print0 | xargs -0 -n1 -I{} sh -c 'if [ -x "{}" ]; then echo "{}"; fi' | sort -z | xargs -0 -n1 sh -c '
+
       printf "\n--> Running $1...\n"
       if [ "$ON_POST_SCRIPT_FAILURE" = "continue" ]; then
         (sudo -E -u '"$POST_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Skipping."; }

--- a/assets/run.sh
+++ b/assets/run.sh
@@ -216,6 +216,8 @@ if [ -d "$INIT_SCRIPTS_DIR" ]; then
       elif [ -x "$1" ]; then
         printf "\n--> Running $1...\n"
         (sudo -E -g '"$INIT_SCRIPTS_USER"' -u '"$INIT_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 7; }
+      else
+        echo "~ $1 is not executable. Skipping."
       fi
     ' sh | awk 'BEGIN{RS="\n";ORS="\n  "}1';
     printf "\n";
@@ -252,6 +254,8 @@ if [ -d "$POST_SCRIPTS_DIR" ]; then
         (sudo -E -u '"$POST_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Skipping."; }
       elif [ -x "$1" ]; then
         (sudo -E -u '"$POST_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 8; }
+      else
+        echo "~ $1 is not executable. Skipping."
       fi
     ' sh | awk 'BEGIN{RS="\n";ORS="\n  "}1';
     printf "\n";

--- a/assets/run.sh
+++ b/assets/run.sh
@@ -210,12 +210,15 @@ if [ -d "$INIT_SCRIPTS_DIR" ]; then
     printf "* Running init-script(s)..."
     # shellcheck disable=SC2016
     find "$INIT_SCRIPTS_DIR" -maxdepth 1 -type f -print0 | sort -z | xargs -0 -n1 sh -c '
-      if [ -x "$1" ] && [ "$ON_INIT_SCRIPT_FAILURE" = "continue" ]; then
+    if  [ -x "$1" ]; then
         printf "\n--> Running $1...\n"
-        (sudo -E -g '"$INIT_SCRIPTS_USER"' -u '"$INIT_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Skipping."; }
-      elif [ -x "$1" ]; then
-        printf "\n--> Running $1...\n"
-        (sudo -E -g '"$INIT_SCRIPTS_USER"' -u '"$INIT_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 7; }
+        (sudo -E -u '"$INIT_SCRIPTS_DIR"' -- $1) || {
+          if [ "$ON_INIT_SCRIPT_FAILURE" = "continue" ]; then
+            echo "x $1 execution failed. Skipping.";
+          else 
+            echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 7;
+          fi
+        }
       else
         echo "~ $1 is not executable. Skipping."
       fi
@@ -249,11 +252,15 @@ if [ -d "$POST_SCRIPTS_DIR" ]; then
     printf "* Running post-script(s)..."
     # shellcheck disable=SC2016
     find "$POST_SCRIPTS_DIR" -maxdepth 1 -type f -print0 | sort -z | xargs -0 -n1 sh -c '
-      if  [ -x "$1" ] && [ "$ON_POST_SCRIPT_FAILURE" = "continue" ]; then
+      if  [ -x "$1" ]; then
         printf "\n--> Running $1...\n"
-        (sudo -E -u '"$POST_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Skipping."; }
-      elif [ -x "$1" ]; then
-        (sudo -E -u '"$POST_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 8; }
+        (sudo -E -u '"$POST_SCRIPTS_USER"' -- $1) || {
+          if [ "$ON_POST_SCRIPT_FAILURE" = "continue" ]; then
+            echo "x $1 execution failed. Skipping.";
+          else 
+            echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 8;
+          fi
+        }
       else
         echo "~ $1 is not executable. Skipping."
       fi


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Debian builds were not working for PHP 5.6 (ex: PS 1.6.1.24). This PR aims at fixing this, but also fixing a bug on `find`, old distributions does not ship such command which support `-executable` as an argument
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #120 #122
| Sponsor company   | PrestaShop
| How to test?      | `OS_FLAVOUR=debian PS_VERSION=1.6.1.24 ./build.sh`
