### PR TITLE
fix: all-in with www-data user

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ PrestaShop Flashlight **does not support** PHP versions prior to PHP 5.6, here i
 | INIT_ON_RESTART            | if enabled the PS_DOMAIN auto search and dump fix will be replayed on container restart                      | `false`                                |
 | INIT_SCRIPTS_DIR           | script directory with executable files to be run prior to PrestaShop startup                                 | `/tmp/init-scripts`                    |
 | INIT_SCRIPTS_ON_RESTART    | if enabled custom init scripts will be replayed on container restart                                         | `false`                                |
-| INIT_SCRIPTS_USER          | the user running the executable files to be run prior to PrestaShop startup                                  | `www-data`                             |
 | INSTALL_MODULES_DIR        | module directory containing zips to be installed with the PrestaShop CLI                                     | empty string (example: `/ps-modules`)  |
 | INSTALL_MODULES_ON_RESTART | if enabled zip modules will be reinstalled on container restart                                              | `false`                                |
 | MYSQL_DATABASE             | MySQL database name                                                                                          | `prestashop`                           |
@@ -99,7 +98,6 @@ PrestaShop Flashlight **does not support** PHP versions prior to PHP 5.6, here i
 | ON_POST_SCRIPT_FAILURE     | if set to `continue`, PrestaShop Flashlight won't exit in case of script failure                             | `fail`                                 |
 | POST_SCRIPTS_DIR           | script directory with executable files to be run after the PrestaShop startup                                | `/tmp/post-scripts`                    |
 | POST_SCRIPTS_ON_RESTART    | if enabled custom post scripts will be replayed on container restart                                         | `false`                                |
-| POST_SCRIPTS_USER          | the user running the executable files to be run after the PrestaShop startup                                 | `www-data`                             |
 | PS_FOLDER                  | prestashop sources directory                                                                                 | `/var/www/html`                        |
 | PS_PROTOCOL                | if PS_PROTOCOL equals `https` the public URL will be `https://$PS_DOMAIN`                                    | `http` (example: `https`)              |
 | SSL_REDIRECT               | if enabled the public URL will be `https://$PS_DOMAIN` (if not using `PS_PROTOCOL`)                          | `false` (example: `true`)              |
@@ -110,6 +108,16 @@ PrestaShop Flashlight **does not support** PHP versions prior to PHP 5.6, here i
 >
 > - ¹required (mutually exclusive with `NGROK_TUNNEL_AUTO_DETECT`)
 > - ²required (mutually exclusive with `PS_DOMAIN`)
+
+## User
+
+PrestaShop Flashlight user is `www-data`, in order to set an example, by applying good security practices.
+However you can anytime run a container with docker, using `--user root` or in your docker-compose file, with `user: root`.
+
+See:
+
+- https://docs.docker.com/reference/cli/docker/container/run/#options
+- https://docs.docker.com/compose/compose-file/05-services/#user
 
 ## Back office access information
 

--- a/assets/alpine-base-install.sh
+++ b/assets/alpine-base-install.sh
@@ -14,9 +14,11 @@ apk --no-cache add -U \
 # Configure php-fpm and nginx
 /tmp/php-configuration.sh
 rm -rf /var/log/php* /etc/php*/php-fpm.conf /etc/php*/php-fpm.d
-mkdir -p /var/log/php /var/run/php /var/run/nginx
-chown nginx:nginx /var/run/nginx
-chown www-data:www-data /var/log/php /var/run/php
+mkdir -p /var/log/php /var/run/php /var/run/nginx /var/log/nginx
+touch /var/log/nginx/access.log /var/log/nginx/error.log
+chown -R nginx:nginx /var/run/nginx /var/log/nginx
+chown -R www-data:www-data /var/log/php /var/run/php "$PHP_INI_DIR"
+setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 # Compute the short version (8.1.27 becomes 8.1)
 PHP_SHORT_VERSION=$(echo "$PHP_VERSION" | cut -d '.' -f1-2)
@@ -24,6 +26,8 @@ PHP_SHORT_VERSION=$(echo "$PHP_VERSION" | cut -d '.' -f1-2)
 # Install composer
 curl -s https://getcomposer.org/installer | php
 mv composer.phar /usr/bin/composer
+mkdir -p "$COMPOSER_HOME"
+chown -R www-data:www-data "$COMPOSER_HOME"
 
 # Install PrestaShop tools required by prestashop coding-standards
 composer require nikic/php-parser --working-dir=/var/opt || true

--- a/assets/alpine-base-install.sh
+++ b/assets/alpine-base-install.sh
@@ -16,8 +16,8 @@ apk --no-cache add -U \
 rm -rf /var/log/php* /etc/php*/php-fpm.conf /etc/php*/php-fpm.d
 mkdir -p /var/log/php /var/run/php /var/run/nginx /var/log/nginx
 touch /var/log/nginx/access.log /var/log/nginx/error.log
-chown -R nginx:nginx /var/run/nginx /var/log/nginx
-chown -R www-data:www-data /var/log/php /var/run/php "$PHP_INI_DIR"
+chown -R www-data:www-data /var/log/php /var/run/php "$PHP_INI_DIR" \
+ /var/run/nginx /var/log/nginx /var/lib/nginx
 setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 # Compute the short version (8.1.27 becomes 8.1)

--- a/assets/alpine-base-install.sh
+++ b/assets/alpine-base-install.sh
@@ -9,7 +9,7 @@ apk --no-cache add -U \
   php-common php-iconv php-gd mariadb-client sudo libjpeg libxml2 \
   build-base linux-headers freetype-dev zlib-dev libjpeg-turbo-dev \
   libpng-dev oniguruma-dev libzip-dev icu-dev libmcrypt-dev libxml2-dev \
-  openssh-client
+  openssh-client libcap
 
 # Configure php-fpm and nginx
 /tmp/php-configuration.sh

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -36,7 +36,7 @@ apt-get install --no-install-recommends -qqy apt-transport-https ca-certificates
 apt-get install --no-install-recommends -o Dpkg::Options::="--force-confold" -qqy bash less vim git sudo mariadb-client \
   tzdata zip unzip curl wget make jq netcat-traditional build-essential \
   lsb-release libgnutls30 gnupg libiconv-hook1 libonig-dev nginx libnginx-mod-http-headers-more-filter libnginx-mod-http-geoip \
-  libnginx-mod-http-geoip libnginx-mod-stream openssh-client;
+  libnginx-mod-http-geoip libnginx-mod-stream openssh-client libcap2;
 if [ "$VERSION_CODENAME" != "stretch" ] && [ "$VERSION_CODENAME" != "buster" ]; then
   echo "deb [trusted=yes] https://packages.sury.org/php/ $VERSION_CODENAME main" > /etc/apt/sources.list.d/php.list
 fi

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -59,11 +59,9 @@ apt-get install --no-install-recommends -qqy \
 /tmp/php-configuration.sh
 rm -rf /var/log/php* /etc/php*/php-fpm.conf /etc/php*/php-fpm.d
 mkdir -p /var/log/php /var/run/php /var/run/nginx /var/log/nginx
-adduser --group nginx
-adduser --system nginx
 touch /var/log/nginx/access.log /var/log/nginx/error.log
-chown -R nginx:nginx /var/run/nginx /var/log/nginx
-chown -R www-data:www-data /var/log/php /var/run/php "$PHP_INI_DIR"
+chown -R www-data:www-data /var/log/php /var/run/php "$PHP_INI_DIR" \
+  /var/run/nginx /var/log/nginx /var/lib/nginx
 setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 # Compute the short version (8.1.27 becomes 8.1)

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -36,7 +36,7 @@ apt-get install --no-install-recommends -qqy apt-transport-https ca-certificates
 apt-get install --no-install-recommends -o Dpkg::Options::="--force-confold" -qqy bash less vim git sudo mariadb-client \
   tzdata zip unzip curl wget make jq netcat-traditional build-essential \
   lsb-release libgnutls30 gnupg libiconv-hook1 libonig-dev nginx libnginx-mod-http-headers-more-filter libnginx-mod-http-geoip \
-  libnginx-mod-http-geoip libnginx-mod-stream openssh-client libcap2;
+  libnginx-mod-http-geoip libnginx-mod-stream openssh-client libcap2-bin;
 if [ "$VERSION_CODENAME" != "stretch" ] && [ "$VERSION_CODENAME" != "buster" ]; then
   echo "deb [trusted=yes] https://packages.sury.org/php/ $VERSION_CODENAME main" > /etc/apt/sources.list.d/php.list
 fi

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -58,18 +58,22 @@ apt-get install --no-install-recommends -qqy \
 # Configure php-fpm and nginx
 /tmp/php-configuration.sh
 rm -rf /var/log/php* /etc/php*/php-fpm.conf /etc/php*/php-fpm.d
-mkdir -p /var/log/php /var/run/php /var/run/nginx
+mkdir -p /var/log/php /var/run/php /var/run/nginx /var/log/nginx
 adduser --group nginx
 adduser --system nginx
-chown nginx:nginx /var/run/nginx
-chown www-data:www-data /var/log/php /var/run/php
+touch /var/log/nginx/access.log /var/log/nginx/error.log
+chown -R nginx:nginx /var/run/nginx /var/log/nginx
+chown -R www-data:www-data /var/log/php /var/run/php "$PHP_INI_DIR"
+setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 # Compute the short version (8.1.27 becomes 8.1)
 PHP_SHORT_VERSION=$(echo "$PHP_VERSION" | cut -d '.' -f1-2)
 
 # Install composer
-curl -s https://getcomposer.org/installer | php \
-  && mv composer.phar /usr/bin/composer
+curl -s https://getcomposer.org/installer | php
+mv composer.phar /usr/bin/composer
+mkdir -p "$COMPOSER_HOME"
+chown -R www-data:www-data "$COMPOSER_HOME"
 
 # Install PrestaShop tools required by prestashop coding-standards
 composer require nikic/php-parser --working-dir=/var/opt

--- a/assets/nginx.conf
+++ b/assets/nginx.conf
@@ -1,5 +1,7 @@
 worker_processes  1;
 pid /var/run/nginx/nginx.pid;
+error_log  stderr notice;
+access_log stdout;
 
 events {
 	worker_connections  1024;
@@ -42,12 +44,7 @@ http {
   server {
     listen 80;
     server_name localhost;
-
-    error_log  /dev/stdout notice;
-    access_log /dev/stdout;
-
     root /var/www/html;
-
     index index.php;
 
     # This should match the `post_max_size` and/or `upload_max_filesize` in your php.ini.

--- a/assets/nginx.conf
+++ b/assets/nginx.conf
@@ -1,4 +1,3 @@
-user www-data www-data;
 worker_processes  1;
 pid /var/run/nginx/nginx.pid;
 

--- a/assets/nginx.conf
+++ b/assets/nginx.conf
@@ -1,7 +1,7 @@
 worker_processes  1;
 pid /var/run/nginx/nginx.pid;
 
-;; ignored when Nginx is not running as root
+# ignored when Nginx is not running as root
 user www-data www-data;
 
 events {

--- a/assets/nginx.conf
+++ b/assets/nginx.conf
@@ -1,8 +1,8 @@
 worker_processes  1;
 pid /var/run/nginx/nginx.pid;
 
-# ignored when Nginx is not running as root
-user www-data www-data;
+## only when running as root
+#user www-data www-data;
 
 events {
 	worker_connections  1024;

--- a/assets/nginx.conf
+++ b/assets/nginx.conf
@@ -15,8 +15,8 @@ http {
   sendfile        on;
   keepalive_timeout  65;
 
-  error_log  stderr notice;
-  access_log stdout;
+  error_log  /dev/stderr notice;
+  access_log /dev/stdout;
 
   gzip on;
   gzip_disable "msie6";

--- a/assets/nginx.conf
+++ b/assets/nginx.conf
@@ -1,7 +1,8 @@
 worker_processes  1;
 pid /var/run/nginx/nginx.pid;
-error_log  stderr notice;
-access_log stdout;
+
+;; ignored when Nginx is not running as root
+user www-data www-data;
 
 events {
 	worker_connections  1024;
@@ -13,6 +14,9 @@ http {
 
   sendfile        on;
   keepalive_timeout  65;
+
+  error_log  stderr notice;
+  access_log stdout;
 
   gzip on;
   gzip_disable "msie6";

--- a/assets/php-fpm.conf
+++ b/assets/php-fpm.conf
@@ -6,9 +6,9 @@ error_log = /var/log/php/php-fpm-errors.log
 listen = /var/run/php/php-fpm.sock
 listen.owner = www-data
 listen.group = www-data
-;; ignored when FPM is not running as root
-user = www-data
-group = www-data
+;; only when running as root
+;user = www-data
+;group = www-data
 
 pm = dynamic
 pm.max_children = 5

--- a/assets/php-fpm.conf
+++ b/assets/php-fpm.conf
@@ -7,8 +7,8 @@ listen = /var/run/php/php-fpm.sock
 listen.owner = www-data
 listen.group = www-data
 ;; ignored when FPM is not running as root
-; user = www-data
-; group = www-data
+user = www-data
+group = www-data
 
 pm = dynamic
 pm.max_children = 5

--- a/assets/run.sh
+++ b/assets/run.sh
@@ -230,10 +230,10 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 echo "* Starting php-fpm..."
-php-fpm -D
+php-fpm -D | grep -v "directive is ignored"
 
 echo "* Starting nginx..."
-nginx -g "daemon off;" &
+nginx -g "daemon off;" | grep -v "ignored in" &
 NGINX_PID=$!
 sleep 1;
 echo "* Nginx started"

--- a/assets/run.sh
+++ b/assets/run.sh
@@ -236,10 +236,18 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 echo "* Starting php-fpm..."
-php-fpm -D | (grep -v "directive is ignored" || true)
+echo "* Disabling user and group for php-fpm..."
+# Is running as root, set the php-fpm user and group to www-data
+if [ "$(id -u)" -eq 0 ]; then
+  sed -i '/user\s=/s/^;//' /usr/local/etc/php-fpm.conf
+  sed -i '/group\s=/s/^;//' /usr/local/etc/php-fpm.conf
+fi
+php-fpm -D
 
 echo "* Starting nginx..."
-nginx -g "daemon off;" | (grep -v "ignored in" || true) &
+# Is running as root, set the nginx user and group to www-data
+[ "$(id -u)" -eq 0 ] && sed -i '/#\suser\swww-data/s/^#//' /etc/nginx/nginx.conf
+nginx -g "daemon off;" &
 NGINX_PID=$!
 sleep 1;
 echo "* Nginx started"

--- a/assets/run.sh
+++ b/assets/run.sh
@@ -236,12 +236,8 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 echo "* Starting php-fpm..."
-echo "* Disabling user and group for php-fpm..."
 # Is running as root, set the php-fpm user and group to www-data
-if [ "$(id -u)" -eq 0 ]; then
-  sed -i '/user\s=/s/^;//' /usr/local/etc/php-fpm.conf
-  sed -i '/group\s=/s/^;//' /usr/local/etc/php-fpm.conf
-fi
+[ "$(id -u)" -eq 0 ] && sed -i '/user\s=/s/^;//' /usr/local/etc/php-fpm.conf && sed -i '/group\s=/s/^;//' /usr/local/etc/php-fpm.conf
 php-fpm -D
 
 echo "* Starting nginx..."

--- a/assets/run.sh
+++ b/assets/run.sh
@@ -230,10 +230,10 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 echo "* Starting php-fpm..."
-php-fpm -D | grep -v "directive is ignored"
+php-fpm -D | (grep -v "directive is ignored" || true)
 
 echo "* Starting nginx..."
-nginx -g "daemon off;" | grep -v "ignored in" &
+nginx -g "daemon off;" | (grep -v "ignored in" || true) &
 NGINX_PID=$!
 sleep 1;
 echo "* Nginx started"

--- a/assets/run.sh
+++ b/assets/run.sh
@@ -8,7 +8,6 @@ export DUMP_ON_RESTART="${DUMP_ON_RESTART:-false}"
 export INIT_ON_RESTART="${INIT_ON_RESTART:-false}"
 export INIT_SCRIPTS_DIR="${INIT_SCRIPTS_DIR:-/tmp/init-scripts/}"
 export INIT_SCRIPTS_ON_RESTART="${INIT_SCRIPTS_ON_RESTART:-false}"
-export INIT_SCRIPTS_USER="${INIT_SCRIPTS_USER:-www-data}"
 export INSTALL_MODULES_DIR="${INSTALL_MODULES_DIR:-}"
 export INSTALL_MODULES_ON_RESTART="${INSTALL_MODULES_ON_RESTART:-false}"
 export MYSQL_VERSION="${MYSQL_VERSION:-5.7}"
@@ -16,7 +15,6 @@ export ON_INIT_SCRIPT_FAILURE="${ON_INIT_SCRIPT_FAILURE:-fail}"
 export ON_INSTALL_MODULES_FAILURE="${ON_INSTALL_MODULES_FAILURE:-fail}"
 export POST_SCRIPTS_DIR="${POST_SCRIPTS_DIR:-/tmp/post-scripts/}"
 export POST_SCRIPTS_ON_RESTART="${POST_SCRIPTS_ON_RESTART:-false}"
-export POST_SCRIPTS_USER="${POST_SCRIPTS_USER:-www-data}"
 export PS_PROTOCOL="${PS_PROTOCOL:-http}"
 export SSL_REDIRECT="${SSL_REDIRECT:-false}"
 export XDEBUG_ENABLED="${XDEBUG_ENABLED:-false}"
@@ -26,11 +24,6 @@ DUMP_LOCK=/tmp/flashlight-dump.lock
 MODULES_INSTALLED_LOCK=/tmp/flashlight-modules-installed.lock
 INIT_SCRIPTS_LOCK=/tmp/flashlight-init-scripts.lock
 POST_SCRIPTS_LOCK=/tmp/flashlight-post-scripts.lock
-
-# Runs everything as www-data
-run_user () {
-  sudo -g www-data -u www-data -- "$@"
-}
 
 if [ ! -f $INIT_LOCK ] || [ "$INIT_ON_RESTART" = "true" ]; then
   if [ -n "${PS_DOMAIN:-}" ]; then
@@ -66,7 +59,12 @@ if [ ! -f $INIT_LOCK ] || [ "$INIT_ON_RESTART" = "true" ]; then
   fi
 
   echo "* Applying PS_DOMAIN ($PS_DOMAIN) to the dump..."
-  sed -i "s~localhost:80~$PS_DOMAIN~g" /dump.sql
+  # Disclaimer: sed -i uses / as this is the parent dir of /dump.sql, don't use it here
+  # to avoid giving full access on /
+  TMP_FILE=$(mktemp)
+  sed "s~localhost:80~$PS_DOMAIN~g" /dump.sql > "$TMP_FILE"
+  cat "$TMP_FILE" > /dump.sql
+  rm -f "$TMP_FILE"
   export PS_DOMAIN="$PS_DOMAIN"
 
   # Note: use PS_TRUSTED_PROXIES for PrestaShop > 9 since bbdee4b6d07cf4c40787c95b8c948b04506208fd
@@ -95,7 +93,7 @@ END
     if [ "$DRY_RUN" = "true" ]; then
       echo "(skipped)";
     else
-      run_user php -r "new PDO('mysql:host=""${MYSQL_HOST}"";port=""${MYSQL_PORT}"";dbname=""${MYSQL_DATABASE}""', '""${MYSQL_USER}""', '""${MYSQL_PASSWORD}""');" 2> /dev/null;
+      php -r "new PDO('mysql:host=""${MYSQL_HOST}"";port=""${MYSQL_PORT}"";dbname=""${MYSQL_DATABASE}""', '""${MYSQL_USER}""', '""${MYSQL_PASSWORD}""');" 2> /dev/null;
     fi
   }
   while ! is_mysql_ready; do echo "Cannot connect to MySQL, retrying in 1s..."; sleep 1; done
@@ -117,7 +115,7 @@ END
 
   if [ -f "$PS_CONFIG_PARAMETERS" ]; then
     [ ! -f "$PS_CONFIG_PARAMETERS.bak" ] && cp "$PS_CONFIG_PARAMETERS" "$PS_CONFIG_PARAMETERS.bak";
-    run_user sed -i \
+    sed -i \
         -e "s~host' => '127.0.0.1'~host' => '$MYSQL_HOST'~" \
         -e "s~port' => ''~port' => '$MYSQL_PORT'~" \
         -e "s~name' => 'prestashop'~name' => '$MYSQL_DATABASE'~" \
@@ -127,7 +125,7 @@ END
       "$PS_FOLDER/app/config/parameters.php"
   elif [ -f "$PS_16_CONFIG_PARAMETERS" ]; then
     [ ! -f "$PS_16_CONFIG_PARAMETERS.bak" ] && cp "$PS_16_CONFIG_PARAMETERS" "$PS_16_CONFIG_PARAMETERS.bak";
-    run_user sed -i \
+    sed -i \
         -e "s~127.0.0.1:3306~$MYSQL_HOST:$MYSQL_PORT~" \
         -e "s~_DB_NAME_', 'prestashop~_DB_NAME_', '$MYSQL_DATABASE~" \
         -e "s~_DB_USER_', 'root~_DB_USER_', '$MYSQL_USER~" \
@@ -188,11 +186,11 @@ if [ ! -f $MODULES_INSTALLED_LOCK ] || [ "$INSTALL_MODULES_ON_RESTART" = "true" 
         module=$(unzip -l "$file" | awk 'NR==4{print $4}' | sed 's/\/$//' | tr "-" "\n" | head -n 1)
         echo "--> Unzipping and installing $module from $file..."
         rm -rf "/var/www/html/modules/${module:-something-at-least}"
-        run_user unzip -qq "$file" -d /var/www/html/modules
+        unzip -qq "$file" -d /var/www/html/modules
         if [ "$ON_INSTALL_MODULES_FAILURE" = "continue" ]; then
-          (run_user php -d memory_limit=-1 bin/console prestashop:module --no-interaction install "$module") || { echo "x module installation failed. Skipping."; }
+          (php -d memory_limit=-1 bin/console prestashop:module --no-interaction install "$module") || { echo "x module installation failed. Skipping."; }
         else
-          (run_user php -d memory_limit=-1 bin/console prestashop:module --no-interaction install "$module") || { echo "x module installation failed. Sleep and exit."; sleep 10; exit 6; }
+          (php -d memory_limit=-1 bin/console prestashop:module --no-interaction install "$module") || { echo "x module installation failed. Sleep and exit."; sleep 10; exit 6; }
         fi
       done;
     else
@@ -212,9 +210,9 @@ if [ -d "$INIT_SCRIPTS_DIR" ]; then
     find "$INIT_SCRIPTS_DIR" -maxdepth 1 -executable -type f -print0 | sort -z | xargs -0 -n1 sh -c '
       printf "\n--> Running $1...\n"
       if [ "$ON_INIT_SCRIPT_FAILURE" = "continue" ]; then
-        (sudo -E -g '"$INIT_SCRIPTS_USER"' -u '"$INIT_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Skipping."; }
+        $1 || { echo "x $1 execution failed. Skipping."; }
       else
-        (sudo -E -g '"$INIT_SCRIPTS_USER"' -u '"$INIT_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 7; }
+        $1 || { echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 7; }
       fi
     ' sh | awk 'BEGIN{RS="\n";ORS="\n  "}1';
     printf "\n";
@@ -232,7 +230,7 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 echo "* Starting php-fpm..."
-run_user php-fpm -D
+php-fpm -D
 
 echo "* Starting nginx..."
 nginx -g "daemon off;" &
@@ -248,9 +246,9 @@ if [ -d "$POST_SCRIPTS_DIR" ]; then
     find "$POST_SCRIPTS_DIR" -maxdepth 1 -executable -type f -print0 | sort -z | xargs -0 -n1 sh -c '
       printf "\n--> Running $1...\n"
       if [ "$ON_POST_SCRIPT_FAILURE" = "continue" ]; then
-        (sudo -E -u '"$POST_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Skipping."; }
+        $1 || { echo "x $1 execution failed. Skipping."; }
       else
-        (sudo -E -u '"$POST_SCRIPTS_USER"' -- $1) || { echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 8; }
+        $1 || { echo "x $1 execution failed. Sleep and exit."; sleep 10; exit 8; }
       fi
     ' sh | awk 'BEGIN{RS="\n";ORS="\n  "}1';
     printf "\n";

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -1,6 +1,6 @@
 ARG PS_VERSION
 ARG PHP_VERSION
-ARG PHP_FLAVOUR
+ARG PHP_FLAVOUR=8.3-fpm-alpine
 ARG GIT_SHA
 ARG NODE_VERSION
 ARG ZIP_SOURCE
@@ -8,7 +8,7 @@ ARG ZIP_SOURCE
 # -------------------------------------
 #  PrestaShop Flashlight: Alpine image
 # -------------------------------------
-FROM php:${PHP_FLAVOUR:-latest} AS alpine-base-prestashop
+FROM php:${PHP_FLAVOUR} AS alpine-base-prestashop
 ARG PS_VERSION
 ARG PHP_VERSION
 ARG NODE_VERSION

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -8,7 +8,7 @@ ARG ZIP_SOURCE
 # -------------------------------------
 #  PrestaShop Flashlight: Alpine image
 # -------------------------------------
-FROM php:${PHP_FLAVOUR} AS alpine-base-prestashop
+FROM php:${PHP_FLAVOUR:-latest} AS alpine-base-prestashop
 ARG PS_VERSION
 ARG PHP_VERSION
 ARG NODE_VERSION

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -97,10 +97,8 @@ ENV DEBUG_MODE=false
 ENV PS_FOLDER=$PS_FOLDER
 ENV MYSQL_EXTRA_DUMP=
 
-# Give rights to www-data user to play with sed and open port 80
 RUN mkdir -p "$COMPOSER_HOME" \
-  && chown -R www-data:www-data "$COMPOSER_HOME" "$PHP_INI_DIR" "/tmp" "/var/www" \
-  && setcap cap_net_bind_service=+ep /usr/sbin/nginx
+  && chown -R www-data:www-data "$COMPOSER_HOME"
 
 # Get the installed sources
 COPY \

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -97,8 +97,10 @@ ENV DEBUG_MODE=false
 ENV PS_FOLDER=$PS_FOLDER
 ENV MYSQL_EXTRA_DUMP=
 
+# Give rights to www-data user to play with sed and open port 80
 RUN mkdir -p "$COMPOSER_HOME" \
-  && chown www-data:www-data "$COMPOSER_HOME"
+  && chown -R www-data:www-data "$COMPOSER_HOME" "$PHP_INI_DIR" "/tmp" "/var/www" \
+  && setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 # Get the installed sources
 COPY \
@@ -118,6 +120,7 @@ COPY --from=build-and-dump \
 # The new default runner
 COPY ./assets/run.sh /run.sh
 
+USER www-data
 HEALTHCHECK --interval=5s --timeout=5s --retries=10 --start-period=10s \
   CMD curl -Isf http://localhost:80/admin-dev/robots.txt || exit 1
 EXPOSE 80

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -99,10 +99,6 @@ ENV DEBUG_MODE=false
 ENV PS_FOLDER=$PS_FOLDER
 ENV MYSQL_EXTRA_DUMP=
 
-# Give rights to www-data user to play with sed and open port 80
-RUN mkdir -p "$COMPOSER_HOME" \
-  && chown -R www-data:www-data "$COMPOSER_HOME" "$PHP_INI_DIR" "/tmp" "/var/www" \
-  && setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 # Get the installed sources
 COPY \

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -99,8 +99,10 @@ ENV DEBUG_MODE=false
 ENV PS_FOLDER=$PS_FOLDER
 ENV MYSQL_EXTRA_DUMP=
 
+# Give rights to www-data user to play with sed and open port 80
 RUN mkdir -p "$COMPOSER_HOME" \
-  && chown www-data:www-data "$COMPOSER_HOME"
+  && chown -R www-data:www-data "$COMPOSER_HOME" "$PHP_INI_DIR" "/tmp" "/var/www" \
+  && setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 # Get the installed sources
 COPY \
@@ -120,6 +122,7 @@ COPY --from=build-and-dump \
 # The new default runner
 COPY ./assets/run.sh /run.sh
 
+USER www-data
 HEALTHCHECK --interval=5s --timeout=5s --retries=10 --start-period=10s \
   CMD curl -Isf http://localhost:80/admin-dev/robots.txt || exit 1
 EXPOSE 80

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -1,6 +1,6 @@
 ARG PS_VERSION
 ARG PHP_VERSION
-ARG PHP_FLAVOUR
+ARG PHP_FLAVOUR=8.3-fpm-bookworm
 ARG GIT_SHA
 ARG NODE_VERSION
 ARG ZIP_SOURCE
@@ -8,7 +8,7 @@ ARG ZIP_SOURCE
 # -------------------------------------
 #  PrestaShop Flashlight: Debian image
 # -------------------------------------
-FROM php:${PHP_FLAVOUR:-latest} AS debian-base-prestashop
+FROM php:${PHP_FLAVOUR} AS debian-base-prestashop
 ARG PS_VERSION
 ARG PHP_VERSION
 ARG GIT_SHA

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -8,7 +8,7 @@ ARG ZIP_SOURCE
 # -------------------------------------
 #  PrestaShop Flashlight: Debian image
 # -------------------------------------
-FROM php:${PHP_FLAVOUR} AS debian-base-prestashop
+FROM php:${PHP_FLAVOUR:-latest} AS debian-base-prestashop
 ARG PS_VERSION
 ARG PHP_VERSION
 ARG GIT_SHA

--- a/prestashop-versions.json
+++ b/prestashop-versions.json
@@ -53,6 +53,15 @@
       "recommended": "16.16.0"
     }
   },
+  "^9": {
+    "php": {
+      "recommended": "8.1",
+      "compatible": ["8.1", "8.2", "8.3"]
+    },
+    "nodejs": {
+      "recommended": "16.16.0"
+    }
+  },
   "nightly": {
     "php": {
       "recommended": "8.1"


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | PrestaShop Flashlight used to be run as root, dropping rights to www-data when necessary (to run init-scripts or post-scripts). The often lead to confusion, developers used to use the PrestaShop CLI under root rights, locking files for the www-user in /var/www/html/modules, or the cache files for instance. <br /><br />I had the choice between completely dropping www-data (thus running everything as root), or going deeper in the rabbit hole, and publish a "secured-by-default" version of Flashlight, running the container with user www-data by default. This last option has been chosen. I hope this won't break anything on your end - it should not. <br /><br />You can anytime refer to [#user](https://github.com/PrestaShop/prestashop-flashlight?tab=readme-ov-file#user) if you want to override defaults and run the container as root.
| Type?             | improvement
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | `docker run -it --rm --entrypoint bash prestashop-flashlight whoami` will answer `www-data`.