### PR TITLE
fix: set uid gid of www-data to 1000

### DIFF
--- a/assets/alpine-base-install.sh
+++ b/assets/alpine-base-install.sh
@@ -9,7 +9,11 @@ apk --no-cache add -U \
   php-common php-iconv php-gd mariadb-client sudo libjpeg libxml2 \
   build-base linux-headers freetype-dev zlib-dev libjpeg-turbo-dev \
   libpng-dev oniguruma-dev libzip-dev icu-dev libmcrypt-dev libxml2-dev \
-  openssh-client libcap
+  openssh-client libcap shadow
+
+# Help mapping to Linux users' host
+usermod -u 1000 www-data
+groupmod -g 1000 www-data
 
 # Configure php-fpm and nginx
 /tmp/php-configuration.sh

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -55,6 +55,10 @@ apt-get install --no-install-recommends -qqy \
   libmcrypt-dev \
   "$LIB_XML_DEV"
 
+# Help mapping to Linux users' host
+usermod -u 1000 www-data
+groupmod -g 1000 www-data
+
 # Configure php-fpm and nginx
 /tmp/php-configuration.sh
 rm -rf /var/log/php* /etc/php*/php-fpm.conf /etc/php*/php-fpm.d


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | As suggested by the community, would be easier for Linux users to have already a 1000 www-data user, which would help while mounting local files to the docker container.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #99
| How to test?      | `docker run -it --rm --entrypoint sh prestashop/prestashop-flashlight id` would give 1000.
