### PR TITLE
fix(build): 1.6  logs flooded by mcrypt_decrypt()

### DIFF
--- a/assets/hydrate.sh
+++ b/assets/hydrate.sh
@@ -76,6 +76,11 @@ sed -ie "s/define('_PS_MODE_DEV_', true);/define('_PS_MODE_DEV_',\ false);/g" "$
 # 8. Make a database dump
 mysqldump -u ${DB_USER} --password=${DB_PASSWD} ${DB_NAME} > ${DUMP_FILE};
 # TODO zip the dump and support both plain and zipped outputs from restoration to allow overrides
+
+# fixing logs flooded by "mcrypt_decrypt() is deprecated"
+if echo "$PS_VERSION" | grep "^1.6" > /dev/null; then
+  sed -i -e "s~'PS_CIPHER_ALGORITHM','1'~'PS_CIPHER_ALGORITHM','0'~" "$DUMP_FILE"
+fi
 echo "✅ MySQL dump performed"
 
 # 9. Cache clear

--- a/assets/patch.sh
+++ b/assets/patch.sh
@@ -3,7 +3,6 @@ set -eu
 
 PS_FOLDER=${PS_FOLDER:?missing PS_FOLDER}
 PS_VERSION=$(awk 'NR==1{print $2}' "$PS_FOLDER/VERSION")
-DUMP_FILE=/dump.sql
 
 add_polyfill_console () {
   mkdir -p "$PS_FOLDER/bin"
@@ -17,8 +16,6 @@ patch_1_6 () {
   echo "User-agent: *" > "$PS_FOLDER/admin/robots.txt"
   echo "Disallow: /" >> "$PS_FOLDER/admin/robots.txt"
   add_polyfill_console
-  # fixing logs flooded by "mcrypt_decrypt() is deprecated"
-  sed -i -e "s~'PS_CIPHER_ALGORITHM','1'~'PS_CIPHER_ALGORITHM','0'~" "$DUMP_FILE"
 }
 
 patch_1_7_6 () {

--- a/assets/patch.sh
+++ b/assets/patch.sh
@@ -3,6 +3,7 @@ set -eu
 
 PS_FOLDER=${PS_FOLDER:?missing PS_FOLDER}
 PS_VERSION=$(awk 'NR==1{print $2}' "$PS_FOLDER/VERSION")
+DUMP_FILE=/dump.sql
 
 add_polyfill_console () {
   mkdir -p "$PS_FOLDER/bin"
@@ -16,6 +17,8 @@ patch_1_6 () {
   echo "User-agent: *" > "$PS_FOLDER/admin/robots.txt"
   echo "Disallow: /" >> "$PS_FOLDER/admin/robots.txt"
   add_polyfill_console
+  # fixing logs flooded by "mcrypt_decrypt() is deprecated"
+  sed -i -e "s~'PS_CIPHER_ALGORITHM','1'~'PS_CIPHER_ALGORITHM','0'~" "$DUMP_FILE"
 }
 
 patch_1_7_6 () {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | PrestaShop 1.6 uses deprecated cipher methods, this disables it from the configuration, and avoid flooding the logs and getting html in json responses...
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #129