### PR TITLE
fix(build): old base image

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -116,12 +116,12 @@ jobs:
         run: ./build.sh
         env:
           PHP_VERSION: ${{ matrix.php_version }}
-          OS_VERSION: ${{ matrix.os_version }}
+          OS_FLAVOUR: ${{ matrix.os_version }}
           TARGET_IMAGE: "flashlight:test"
           BASE_ONLY: "true"
 
       - name: Test the image with a dry run
-        run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' flashlight:test
+        run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' --user www-data flashlight:test
 
   docker_build_debian:
     name: "Docker build: PS ${{ matrix.ps_version }} for debian"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -104,8 +104,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php_version:
-          ["5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
+        php_version: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
         os_version: ["alpine", "debian"]
     needs: [docker_dry_build]
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -97,15 +97,14 @@ jobs:
       - name: Test the image tooling(xdebug)
         run: docker run --env PS_DOMAIN='localhost:80' --entrypoint bash flashlight:${{ matrix.ps_version }} -c 'php -m -c | grep xdebug'
 
-  docker_build_base:
-    name: "Docker build: PrestaShop with PHP ${{ matrix.php_version }} ${{ matrix.os_version }}"
+  docker_build_base_alpine:
+    name: "Docker build: PrestaShop with PHP ${{ matrix.php_version }} alpine"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: true
       matrix:
-        php_version: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
-        os_version: ["alpine", "debian"]
+        php_version: ["5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
     needs: [docker_dry_build]
     steps:
       - name: Checkout repository
@@ -115,7 +114,31 @@ jobs:
         run: ./build.sh
         env:
           PHP_VERSION: ${{ matrix.php_version }}
-          OS_FLAVOUR: ${{ matrix.os_version }}
+          OS_FLAVOUR: alpine
+          TARGET_IMAGE: "flashlight:test"
+          BASE_ONLY: "true"
+
+      - name: Test the image with a dry run
+        run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' --user www-data flashlight:test
+
+  docker_build_base_debian:
+    name: "Docker build: PrestaShop with PHP ${{ matrix.php_version }} debian"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: true
+      matrix:
+        php_version: ["8.0", "8.1", "8.2", "8.3"]
+    needs: [docker_dry_build]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Call the docker build chain
+        run: ./build.sh
+        env:
+          PHP_VERSION: ${{ matrix.php_version }}
+          OS_FLAVOUR: debian
           TARGET_IMAGE: "flashlight:test"
           BASE_ONLY: "true"
 
@@ -130,7 +153,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ps_version: ["1.6.1.24", "1.7.6.9", "1.7.7.8", "1.7.8.11", "8.1.7"]
+        ps_version: ["8.1.7"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -80,31 +80,22 @@ jobs:
         env:
           PS_VERSION: ${{ matrix.ps_version }}
           REBUILD_BASE: "true"
+          TARGET_IMAGE: "flashlight:${{ matrix.ps_version }}"
 
       - name: Test the image with a dry run
-        run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' $DOCKER_IMAGE
-        env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:${{ matrix.ps_version }}
+        run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' flashlight:${{ matrix.ps_version }}
 
       - name: Test the image tooling(composer)
-        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint composer $DOCKER_IMAGE --version
-        env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:${{ matrix.ps_version }}
+        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint composer flashlight:${{ matrix.ps_version }} --version
 
       - name: Test the image tooling(phpunit)
-        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint phpunit $DOCKER_IMAGE --version
-        env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:${{ matrix.ps_version }}
+        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint phpunit flashlight:${{ matrix.ps_version }} --version
 
       - name: Test the image tooling(phpstan)
-        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint phpstan $DOCKER_IMAGE --version
-        env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:${{ matrix.ps_version }}
+        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint phpstan flashlight:${{ matrix.ps_version }} --version
 
       - name: Test the image tooling(xdebug)
-        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint bash $DOCKER_IMAGE -c 'php -m -c | grep xdebug'
-        env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:${{ matrix.ps_version }}
+        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint bash flashlight:${{ matrix.ps_version }} -c 'php -m -c | grep xdebug'
 
   docker_build_base:
     name: "Docker build: PrestaShop with PHP ${{ matrix.php_version }} {{ matrix.os_version }}"
@@ -126,13 +117,11 @@ jobs:
         env:
           PHP_VERSION: ${{ matrix.php_version }}
           OS_VERSION: ${{ matrix.os_version }}
-          TARGET_IMAGE: "prestashop/prestashop-flashlight:test"
+          TARGET_IMAGE: "flashlight:test"
           BASE_ONLY: "true"
 
       - name: Test the image with a dry run
-        run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' $DOCKER_IMAGE
-        env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:test
+        run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' flashlight:test
 
   docker_build_debian:
     name: "Docker build: PS ${{ matrix.ps_version }} for debian"
@@ -152,17 +141,14 @@ jobs:
         env:
           OS_FLAVOUR: "debian"
           PS_VERSION: ${{ matrix.ps_version }}
+          TARGET_IMAGE: "flashlight:${{ matrix.ps_version }}-debian"
           REBUILD_BASE: "true"
 
       - name: Test the image with a dry run
-        run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' $DOCKER_IMAGE
-        env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:${{ matrix.ps_version }}-debian
+        run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' flashlight:${{ matrix.ps_version }}-debian
 
       - name: The image has a PrestaShop console CLI
-        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint /bin/ls $DOCKER_IMAGE bin/console
-        env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:${{ matrix.ps_version }}-debian
+        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint /bin/ls flashlight:${{ matrix.ps_version }}-debian bin/console
 
   docker_build_nightly:
     name: "Docker build: PS nightly"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -106,13 +106,15 @@ jobs:
         env:
           DOCKER_IMAGE: prestashop/prestashop-flashlight:${{ matrix.ps_version }}
 
-  docker_build_old_php:
-    name: "Docker build: PrestaShop with PHP 5.6"
+  docker_build_base:
+    name: "Docker build: PrestaShop with PHP ${{ matrix.php_version }} {{ matrix.os_version }}"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: true
       matrix:
+        php_version:
+          ["5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
         os_version: ["alpine", "debian"]
     needs: [docker_dry_build]
     steps:
@@ -122,15 +124,15 @@ jobs:
       - name: Call the docker build chain
         run: ./build.sh
         env:
-          PS_VERSION: 1.6.1.24
-          PHP_VERSION: 5.6
+          PHP_VERSION: ${{ matrix.php_version }}
           OS_VERSION: ${{ matrix.os_version }}
-          REBUILD_BASE: "true"
+          TARGET_IMAGE: "prestashop/prestashop-flashlight:test"
+          BASE_ONLY: "true"
 
       - name: Test the image with a dry run
         run: docker run --env PS_DOMAIN='localhost:80' --env DRY_RUN='true' $DOCKER_IMAGE
         env:
-          DOCKER_IMAGE: prestashop/prestashop-flashlight:1.6.1.24-${{ matrix.os_version }}
+          DOCKER_IMAGE: prestashop/prestashop-flashlight:test
 
   docker_build_debian:
     name: "Docker build: PS ${{ matrix.ps_version }} for debian"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -98,7 +98,7 @@ jobs:
         run: docker run --env PS_DOMAIN='localhost:80' --entrypoint bash flashlight:${{ matrix.ps_version }} -c 'php -m -c | grep xdebug'
 
   docker_build_base:
-    name: "Docker build: PrestaShop with PHP ${{ matrix.php_version }} {{ matrix.os_version }}"
+    name: "Docker build: PrestaShop with PHP ${{ matrix.php_version }} ${{ matrix.os_version }}"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ You can check this implementation anytime in [prestashop-version.json](./prestas
 | 8.0~8.1                       | PHP 7.2 - 8.1          |
 | nightly                       | PHP 8.1 - 8.3          |
 
-PrestaShop Flashlight **does not support** PHP versions prior to PHP 5.6 with Alpine Linux, 7.1 with Debian, here is why:
+PrestaShop Flashlight **does not support** PHP versions prior to PHP 5.6 with Alpine Linux, 8.0 with Debian, here is why:
 
 - Official PHP docker images are very old for PHP 5.2, 5.3, 5.4... til the point docker images do not comply with current docker engines.
 - Old debian / alpine OS releases do not support arm64 builds and packages
 - Rebuilding legacy PHP environments compatible with moddern docker images is costly, with a low value for Flashlight
 - Migrating from PHP 5.2 to 5.6 might not be a hard task for an agency/merchant.
-- Sury repositories dropped support for Debian Jessie & Stretch
+- Sury repositories dropped support for Debian Jessie, Stretch & Buster
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ You can check this implementation anytime in [prestashop-version.json](./prestas
 | 8.0~8.1                       | PHP 7.2 - 8.1          |
 | nightly                       | PHP 8.1 - 8.3          |
 
-PrestaShop Flashlight **does not support** PHP versions prior to PHP 5.6, here is why:
+PrestaShop Flashlight **does not support** PHP versions prior to PHP 5.6 with Alpine Linux, 7.1 with Debian, here is why:
 
 - Official PHP docker images are very old for PHP 5.2, 5.3, 5.4... til the point docker images do not comply with current docker engines.
 - Old debian / alpine OS releases do not support arm64 builds and packages
 - Rebuilding legacy PHP environments compatible with moddern docker images is costly, with a low value for Flashlight
 - Migrating from PHP 5.2 to 5.6 might not be a hard task for an agency/merchant.
+- Sury repositories dropped support for Debian Jessie & Stretch
 
 ## Environment variables
 

--- a/assets/alpine-base-install.sh
+++ b/assets/alpine-base-install.sh
@@ -120,6 +120,13 @@ fi
 # Install Node.js (shipping yarn and npm) and pnpm
 if [ "0.0.0" != "$NODE_VERSION" ]; then
   apk --no-cache add -U python3 nodejs npm yarn
+
+  # see https://stackoverflow.com/a/52196681
+  NODE_MAJOR_VERSION=$(node -v | cut -d '.' -f1 | tr -d 'v')
+  if [ "$NODE_MAJOR_VERSION" -lt 14 ]; then
+    npm config set unsafe-perm true
+  fi
+  
   npm install -g pnpm@latest
 fi
 

--- a/assets/alpine-base-install.sh
+++ b/assets/alpine-base-install.sh
@@ -2,18 +2,15 @@
 set -eu
 
 # Install base tools, PHP requirements and dev-tools
+PHP_COMMON=$(apk search -a 'php-common' | awk 'NR==1{print $1}')
+PHP_ICONV=$(apk search -a 'php-iconv' | awk 'NR==1{print $1}')
+PHP_GD=$(apk search -a 'php-gd' | awk 'NR==1{print $1}')
 packages="bash less vim geoip git tzdata zip curl jq autoconf findutils \
   ca-certificates \
   mariadb-client sudo libjpeg libxml2 \
   build-base linux-headers freetype-dev zlib-dev libjpeg-turbo-dev \
   libpng-dev oniguruma-dev libzip-dev icu-dev libmcrypt-dev libxml2-dev \
-  openssh-client libcap shadow"
-
-if [ "$PHP_VERSION" = "7.0" ] || [ "$PHP_VERSION" = "7.1" ] || [ "$PHP_VERSION" = "7.2" ]; then
-  packages="$packages php7-common php7-iconv php7-gd"
-else
-  packages="$packages php-common php-iconv php-gd"
-fi
+  openssh-client libcap shadow $PHP_COMMON $PHP_ICONV $PHP_GD"
 
 if [ "$SERVER_FLAVOUR" = "nginx" ]; then
   packages="$packages nginx nginx-mod-http-headers-more nginx-mod-http-geoip nginx-mod-stream nginx-mod-stream-geoip"
@@ -131,14 +128,12 @@ fi
 
 # Install Node.js (shipping yarn and npm) and pnpm
 if [ "0.0.0" != "$NODE_VERSION" ]; then
-  packagesForNode=python3
+  APK_NODE_JS="nodejs npm yarn"
   if [ "$PHP_VERSION" = "7.0" ] || [ "$PHP_VERSION" = "7.1" ] || [ "$PHP_VERSION" = "7.2" ]; then
-    packagesForNode="$packagesForNode nodejs-npm yarn"
-  else
-    packagesForNode="$packagesForNode nodejs npm yarn"
+    APK_NODE_JS="nodejs-npm yarn"
   fi
   # shellcheck disable=SC2086
-  set -- $packagesForNode
+  set -- $APK_NODE_JS python3 sqlite-dev
   apk --no-cache add -U "$@"
 
   # see https://stackoverflow.com/a/52196681

--- a/assets/alpine-base-install.sh
+++ b/assets/alpine-base-install.sh
@@ -9,7 +9,7 @@ packages="bash less vim geoip git tzdata zip curl jq autoconf findutils \
   libpng-dev oniguruma-dev libzip-dev icu-dev libmcrypt-dev libxml2-dev \
   openssh-client libcap shadow"
 
-if [ "$(printf '%s' "$PHP_VERSION" | cut -c 1)" = "7" ]; then
+if [ "$PHP_VERSION" = "7.0" ] || [ "$PHP_VERSION" = "7.1" ] || [ "$PHP_VERSION" = "7.2" ]; then
   packages="$packages php7-common php7-iconv php7-gd"
 else
   packages="$packages php-common php-iconv php-gd"
@@ -105,7 +105,13 @@ fi
 # Install phpstan
 PHPSTAN_VERSION=$(jq -r '."'"${PHP_SHORT_VERSION}"'".phpstan' < /tmp/php-flavours.json)
 if [ "$PHPSTAN_VERSION" != "null" ]; then
-  wget -q -O /usr/bin/phpstan "https://github.com/phpstan/phpstan/releases/download/${PHPSTAN_VERSION}/phpstan.phar"
+
+  PHP_STAN_DL_URL="https://github.com/phpstan/phpstan/releases/download/${PHPSTAN_VERSION}/phpstan.phar"
+  if [ "$PHPSTAN_VERSION" = "HEAD" ]; then
+    PHP_STAN_DL_URL="https://github.com/phpstan/phpstan/raw/HEAD/phpstan.phar"
+  fi
+
+  wget -q -O /usr/bin/phpstan "$PHP_STAN_DL_URL"
   chmod a+x /usr/bin/phpstan
 fi
 
@@ -126,7 +132,7 @@ fi
 # Install Node.js (shipping yarn and npm) and pnpm
 if [ "0.0.0" != "$NODE_VERSION" ]; then
   packagesForNode=python3
-  if [ "$(printf '%s' "$PHP_VERSION" | cut -c 1)" = "7" ]; then
+  if [ "$PHP_VERSION" = "7.0" ] || [ "$PHP_VERSION" = "7.1" ] || [ "$PHP_VERSION" = "7.2" ]; then
     packagesForNode="$packagesForNode nodejs-npm yarn"
   else
     packagesForNode="$packagesForNode nodejs npm yarn"

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -53,7 +53,7 @@ apt-get install --no-install-recommends -o Dpkg::Options::="--force-confold" --f
 if [ "$VERSION_CODENAME" = "bookworm" ] || [ "$VERSION_CODENAME" = "bullseye" ]; then
   echo "deb [trusted=yes] https://packages.sury.org/php/ $VERSION_CODENAME main" > /etc/apt/sources.list.d/php.list
 else
-  echo "[WARNING] The sury repository does not support debian jessie or stretch any more."
+  echo "[WARNING] The sury repository does not support debian jessie, stretch or buster any more."
   echo "This build is likely to fail, please use an alpine build if you can."
   echo "see: https://packages.sury.org/php/dists/"
   exit 6

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -50,7 +50,7 @@ fi
 
 apt-get install --no-install-recommends -o Dpkg::Options::="--force-confold" --force-yes -qqy "${packages[@]}"
 
-if [ "$VERSION_CODENAME" = "bookworm" ] && [ "$VERSION_CODENAME" = "bullseye" ]; then
+if [ "$VERSION_CODENAME" = "bookworm" ] || [ "$VERSION_CODENAME" = "bullseye" ]; then
   echo "deb [trusted=yes] https://packages.sury.org/php/ $VERSION_CODENAME main" > /etc/apt/sources.list.d/php.list
 else
   echo "[WARNING] The sury repository does not support debian jessie or stretch any more."

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -43,8 +43,7 @@ packages=(bash less vim git sudo mariadb-client \
   tzdata zip unzip curl wget make jq netcat-traditional build-essential \
   lsb-release "$LIB_GNUTLS" gnupg libiconv-hook1 libonig-dev openssh-client libcap2-bin)
 if [ "$SERVER_FLAVOUR" = "nginx" ]; then
-  packages+=(nginx libnginx-mod-http-headers-more-filter libnginx-mod-http-geoip \
-  libnginx-mod-http-geoip libnginx-mod-stream)
+  packages+=(nginx-full)
 else
   packages+=(apache2)
 fi

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -37,21 +37,21 @@ curl -s -L -H "Content-Type: application/octet-stream" \
   --data-binary "@/etc/apt/trusted.gpg.d/php.gpg" \
   "https://packages.sury.org/php/apt.gpg"
 apt-get update
-apt-get install --no-install-recommends -qqy apt-transport-https ca-certificates
+apt-get install --no-install-recommends --force-yes -qqy apt-transport-https ca-certificates
+LIB_GNUTLS=$(apt-cache search '^libgnutls' | awk 'NR==1{print $1}')
 packages=(bash less vim git sudo mariadb-client \
   tzdata zip unzip curl wget make jq netcat-traditional build-essential \
-  lsb-release libgnutls30 gnupg libiconv-hook1 libonig-dev libnginx-mod-http-headers-more-filter libnginx-mod-http-geoip \
-  libnginx-mod-http-geoip libnginx-mod-stream openssh-client libcap2-bin)
+  lsb-release "$LIB_GNUTLS" gnupg libiconv-hook1 libonig-dev openssh-client libcap2-bin)
 if [ "$SERVER_FLAVOUR" = "nginx" ]; then
-  packages+=(nginx)
+  packages+=(nginx libnginx-mod-http-headers-more-filter libnginx-mod-http-geoip \
+  libnginx-mod-http-geoip libnginx-mod-stream)
 else
   packages+=(apache2)
 fi
 
-apt-get install --no-install-recommends -o Dpkg::Options::="--force-confold" -qqy "${packages[@]}"
+apt-get install --no-install-recommends -o Dpkg::Options::="--force-confold" --force-yes -qqy "${packages[@]}"
 
-
-if [ "$VERSION_CODENAME" != "stretch" ] && [ "$VERSION_CODENAME" != "buster" ]; then
+if [ "$VERSION_CODENAME" != "stretch" ] && [ "$VERSION_CODENAME" != "buster" ] && [ "$VERSION_CODENAME" != "jessie" ]; then
   echo "deb [trusted=yes] https://packages.sury.org/php/ $VERSION_CODENAME main" > /etc/apt/sources.list.d/php.list
 fi
 rm /etc/apt/preferences.d/no-debian-php

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -50,8 +50,13 @@ fi
 
 apt-get install --no-install-recommends -o Dpkg::Options::="--force-confold" --force-yes -qqy "${packages[@]}"
 
-if [ "$VERSION_CODENAME" != "stretch" ] && [ "$VERSION_CODENAME" != "buster" ] && [ "$VERSION_CODENAME" != "jessie" ]; then
+if [ "$VERSION_CODENAME" = "bookworm" ] && [ "$VERSION_CODENAME" = "bullseye" ]; then
   echo "deb [trusted=yes] https://packages.sury.org/php/ $VERSION_CODENAME main" > /etc/apt/sources.list.d/php.list
+else
+  echo "[WARNING] The sury repository does not support debian jessie or stretch any more."
+  echo "This build is likely to fail, please use an alpine build if you can."
+  echo "see: https://packages.sury.org/php/dists/"
+  exit 6
 fi
 rm /etc/apt/preferences.d/no-debian-php
 apt-get update

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -13,6 +13,7 @@ rm -rf /usr/share/doc \
   /usr/share/locale
 
 # Get debian version and codename
+VERSION_CODENAME=""
 # shellcheck disable=SC1091
 . /etc/os-release
 if [ "$VERSION_ID" = 9 ]; then

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -16,12 +16,16 @@ rm -rf /usr/share/doc \
 VERSION_CODENAME=""
 # shellcheck disable=SC1091
 . /etc/os-release
-if [ "$VERSION_ID" = 9 ]; then
+if [ "$VERSION_ID" = 8 ]; then
+  export VERSION_CODENAME="jessie";
+elif [ "$VERSION_ID" = 9 ]; then
   export VERSION_CODENAME="stretch";
 fi
 
 # https://unix.stackexchange.com/a/743874
-if [ "$VERSION_CODENAME" = "stretch"  ]; then
+if [ "$VERSION_CODENAME" = "jessie"  ]; then
+  echo "deb [check-valid-until=no] http://archive.debian.org/debian/ jessie main contrib non-free" > /etc/apt/sources.list
+elif [ "$VERSION_CODENAME" = "stretch"  ]; then
   sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
   sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
   sed -i s/stretch-updates/stretch/g /etc/apt/sources.list

--- a/assets/hydrate.sh
+++ b/assets/hydrate.sh
@@ -100,8 +100,9 @@ PS_OPT_DIR=/var/opt/prestashop
 mkdir -p "$PS_OPT_DIR"
 if echo "$PS_VERSION" | grep "^1.6" > /dev/null; then
   cp "$PS_FOLDER/config/settings.inc.php" "$PS_OPT_DIR/settings.inc.php"
+elif [ -f "$PS_FOLDER/app/config/parameters.yml.dist" ]; then
+  cp "$PS_FOLDER/app/config/parameters.yml.dist" "$PS_OPT_DIR/parameters.yml"
 else
-  mkdir -p "$PS_OPT_DIR"
   cp "$PS_FOLDER/app/config/parameters.php" "$PS_OPT_DIR/parameters.php"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -227,11 +227,9 @@ fi
 
 if [ -z "${TARGET_IMAGE:+x}" ]; then
   read -ra TARGET_IMAGES <<<"$(get_target_images "$PHP_BASE_IMAGE" "$PS_VERSION" "$PHP_VERSION" "$OS_FLAVOUR")"
-  read -ra TARGET_BASE_IMAGES <<<"-t $TARGET_IMAGE_NAME:base-${PHP_BASE_IMAGE}-${SERVER_FLAVOUR}"
   BASE_DOCKER_IMAGE="$TARGET_IMAGE_NAME:base-${PHP_BASE_IMAGE}-${SERVER_FLAVOUR}"
 else
   read -ra TARGET_IMAGES <<<"-t $TARGET_IMAGE"
-  read -ra TARGET_BASE_IMAGES <<<"-t $TARGET_IMAGE"
   BASE_DOCKER_IMAGE="$TARGET_IMAGE"
 fi
 
@@ -280,7 +278,7 @@ if [ "$REBUILD_BASE" == "true" ]; then
     --build-arg GIT_SHA="$GIT_SHA" \
     --build-arg SERVER_FLAVOUR="$SERVER_FLAVOUR" \
     "${LABELS[@]}" \
-    "${TARGET_BASE_IMAGES[@]}" \
+    -t "$BASE_DOCKER_IMAGE" \
     "$([ "${PUSH}" == "true" ] && echo "--push" || echo "--load")" \
     .
 fi

--- a/build.sh
+++ b/build.sh
@@ -5,28 +5,20 @@ cd "$(dirname "$0")"
 # Available variables
 # -------------------
 declare BASE_ONLY;             # -- only build the base image (OS_FLAVOUR) without shipping PrestaShop
-declare REBUILD_BASE;          # -- force the rebuild of the base image
+declare CUSTOM_LABELS;         # -- A comma separated list of key=value pairs, for overriding official flashlight labels"
 declare DRY_RUN;               # -- if used, won't really build the image. Useful to check tags compliance
 declare OS_FLAVOUR;            # -- either "alpine" (default) or "debian"
 declare PHP_VERSION;           # -- PHP version, defaults to recommended version for PrestaShop
+declare PLATFORM;              # -- alias for $TARGET_PLATFORM
 declare PS_VERSION;            # -- PrestaShop version, defaults to latest
 declare PUSH;                  # -- set it to "true" if you want to push the resulting image
+declare REBUILD_BASE;          # -- force the rebuild of the base image
 declare SERVER_FLAVOUR;        # -- either "nginx" (default) or "apache"
-declare TARGET_IMAGE;          # -- docker image name, defaults to "prestashop/prestashop-flashlight"
-declare TARGET_PLATFORM;       # -- a comma separated list of target platforms (defaults to "linux/amd64")
-declare PLATFORM;              # -- alias for $TARGET_PLATFORM
+declare TARGET_IMAGE;          # -- docker image name and tag, defaults to "$TARGET_IMAGE_NAME:$TARGET_IMAGE_TAG"
+declare TARGET_IMAGE_NAME;     # -- docker image name, defaults to "prestashop/prestashop-flashlight"
+declare TARGET_IMAGE_TAG;      # -- docker image tag, defaults to automatic tags based on the os flavour, php and prestashop versions
+declare TARGET_PLATFORM;       # -- a comma separated list of target platforms, defaults to "linux/amd64"
 declare ZIP_SOURCE;            # -- the zip to unpack in flashlight
-declare CUSTOM_LABELS;         # -- A comma separated list of key=value pairs, for overriding official flashlight labels"
-declare CUSTOM_BASE_IMAGE;     # -- A name for overriding the base docker image. Usefull if you need to build the base to a custom repo
-
-
-# Static configuration
-# --------------------
-DEFAULT_BASE_DOCKER_IMAGE=prestashop/prestashop-flashlight
-DEFAULT_OS="alpine";
-DEFAULT_PLATFORM=$(docker system info --format '{{.OSType}}/{{.Architecture}}')
-DEFAULT_SERVER="nginx";
-GIT_SHA=$(git rev-parse HEAD)
 
 error() {
   echo "$(tput bold)$(tput setaf 1)${1:-Unknown error}$(tput sgr0)"
@@ -37,36 +29,38 @@ help() {
   echo "$(tput bold)Usage:$(tput sgr0) $0 [options]"
   echo
   echo "$(tput bold)Options:$(tput sgr0)"
-  echo "  --help            Display this help message"
-  echo "  --base-only       Only build the base image (OS_FLAVOUR) without shipping PrestaShop"
-  echo "  --dry-run         Don't really build the image. Useful to check tags compliance"
-  echo "  --os-flavour      Either 'alpine' (default) or 'debian'"
-  echo "  --php-version     PHP version, defaults to recommended version for PrestaShop"
-  echo "  --platform        Alias for --target-platform"
-  echo "  --ps-version      PrestaShop version, defaults to latest"
-  echo "  --push            Push the resulting image to the registry"
-  echo "  --rebuild-base    Force the rebuild of the base image"
-  echo "  --server-flavour  Either 'nginx' (default) or 'apache'"
-  echo "  --target-image    Docker image name, defaults to 'prestashop/prestashop-flashlight'"
-  echo "  --custom-labels   A comma separated list of key=value pairs, for overriding official flashlight labels"
-  echo "  --target-platform A comma separated list of target platforms (defaults to 'linux/amd64')"
-  echo "  --zip-source      The zip containing the PrestaShop release to build a docker image upon (defaults to PrestaShop source code)"
-  echo "  --custom-base-image A name for overriding the base docker image. Usefull if you need to build the base to a custom repo"
+  echo "  --help               Display this help message"
+  echo "  --base-only          Only build the base image (OS_FLAVOUR) without shipping PrestaShop"
+  echo "  --custom-labels      A comma separated list of key=value pairs, for overriding official flashlight labels"
+  echo "  --dry-run            Don't really build the image. Useful to check tags compliance"
+  echo "  --os-flavour         Either 'alpine' (default) or 'debian'"
+  echo "  --php-version        PHP version, defaults to recommended version for PrestaShop"
+  echo "  --platform           Alias for --target-platform"
+  echo "  --ps-version         PrestaShop version, defaults to latest"
+  echo "  --push               Push the resulting image to the registry"
+  echo "  --rebuild-base       Force the rebuild of the base image"
+  echo "  --server-flavour     Either 'nginx' (default) or 'apache'"
+  echo "  --target-image       Docker image name and tag, defaults to TARGET_IMAGE_NAME:TARGET_IMAGE_TAG"
+  echo "  --target-image-name  Docker image name, defaults to \"prestashop/prestashop-flashlight\""
+  echo "  --target-image-tag   Docker image tag, defaults to automatic tags based on the os flavour, php and prestashop versions"
+  echo "  --target-platform    A comma separated list of target platforms, defaults to 'linux/amd64'"
+  echo "  --zip-source         The zip containing the PrestaShop release to build a docker image upon (defaults to PrestaShop source code)"
   echo ""
   echo "$(tput bold)Environment variables:$(tput sgr0)"
-  echo "  BASE_ONLY         Only build the base image (OS_FLAVOUR) without shipping PrestaShop"
-  echo "  DRY_RUN           Don't really build the image. Useful to check tags compliance"
-  echo "  OS_FLAVOUR        Either 'alpine' (default) or 'debian'"
-  echo "  PHP_VERSION       PHP version, defaults to recommended version for PrestaShop"
-  echo "  PS_VERSION        PrestaShop version, defaults to latest"
-  echo "  PUSH              Set it to 'true' if you want to push the resulting image"
-  echo "  REBUILD_BASE      Force the rebuild of the base image"
-  echo "  SERVER_FLAVOUR    Either 'nginx' (default) or 'apache'"
-  echo "  TARGET_IMAGE      Docker image name, defaults to 'prestashop/prestashop-flashlight'"
-  echo "  CUSTOM_LABELS     A comma separated list of key=value pairs, for overriding official flashlight labels"
-  echo "  TARGET_PLATFORM   A comma separated list of target platforms (defaults to 'linux/amd64')"
-  echo "  ZIP_SOURCE        The zip containing the PrestaShop release to build a docker image upon (defaults to PrestaShop source code)"
-  echo "  CUSTOM_BASE_IMAGE A name for overriding the base docker image. Usefull if you need to build the base to a custom repo"
+  echo "  BASE_ONLY          Only build the base image (OS_FLAVOUR) without shipping PrestaShop"
+  echo "  CUSTOM_LABELS      A comma separated list of key=value pairs, for overriding official flashlight labels"
+  echo "  DRY_RUN            Don't really build the image. Useful to check tags compliance"
+  echo "  OS_FLAVOUR         Either 'alpine' (default) or 'debian'"
+  echo "  PHP_VERSION        PHP version, defaults to recommended version for PrestaShop"
+  echo "  PS_VERSION         PrestaShop version, defaults to latest"
+  echo "  PUSH               Set it to 'true' if you want to push the resulting image"
+  echo "  REBUILD_BASE       Force the rebuild of the base image"
+  echo "  SERVER_FLAVOUR     Either 'nginx' (default) or 'apache'"
+  echo "  TARGET_IMAGE       Docker image name, defaults to TARGET_IMAGE_NAME:TARGET_IMAGE_TAG"
+  echo "  TARGET_IMAGE_NAME  Docker image name, defaults to \"prestashop/prestashop-flashlight\""
+  echo "  TARGET_IMAGE_TAG   Docker image tag, defaults to automatic tags based on the os flavour, php and prestashop versions"
+  echo "  TARGET_PLATFORM    A comma separated list of target platforms, defaults to 'linux/amd64'"
+  echo "  ZIP_SOURCE         The zip containing the PrestaShop release to build a docker image upon (defaults to PrestaShop source code)"
 }
 
 # Parsing input arguments
@@ -75,6 +69,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --help) help; exit 0;;
     --base-only) BASE_ONLY=true; shift;;
+    --custom-labels) CUSTOM_LABELS="$2"; shift; shift;;
     --dry-run) DRY_RUN=true; shift;;
     --os-flavour) OS_FLAVOUR="$2"; shift; shift;;
     --php-version) PHP_VERSION="$2"; shift; shift;;
@@ -84,21 +79,24 @@ while [ "$#" -gt 0 ]; do
     --rebuild-base) REBUILD_BASE=true; shift;;
     --server-flavour) SERVER_FLAVOUR="$2"; shift; shift;;
     --target-image) TARGET_IMAGE="$2"; shift; shift;;
-    --custom-labels) CUSTOM_LABELS="$2"; shift; shift;;
+    --target-image-name) TARGET_IMAGE_NAME="$2"; shift; shift;;
+    --target-image-tag) TARGET_IMAGE_TAG="$2"; shift; shift;;
     --zip-source) ZIP_SOURCE="$2"; shift; shift;;
-    --custom-base-image) CUSTOM_BASE_IMAGE="$2"; shift; shift;;
     *) error "Unknown option: $1" 2;;
   esac
 done
 
 # Default configuration
 # ---------------------
-PUSH=${PUSH:-false}
 BASE_ONLY=${BASE_ONLY:-false}
-REBUILD_BASE=${REBUILD_BASE:-$BASE_ONLY}
+DEFAULT_OS="alpine";
+DEFAULT_PLATFORM=$(docker system info --format '{{.OSType}}/{{.Architecture}}')
+DEFAULT_SERVER="nginx";
 DRY_RUN=${DRY_RUN:-false}
+GIT_SHA=$(git rev-parse HEAD)
+PUSH=${PUSH:-false}
+REBUILD_BASE=${REBUILD_BASE:-$BASE_ONLY}
 TARGET_PLATFORM="${TARGET_PLATFORM:-${PLATFORM:-$DEFAULT_PLATFORM}}"
-BASE_DOCKER_IMAGE="${CUSTOM_BASE_IMAGE:-${DEFAULT_BASE_DOCKER_IMAGE}}"
 LABELS=(
   "--label" "org.opencontainers.image.title=\"Prestashop Flashlight\""
   "--label" "org.opencontainers.image.description=\"PrestaShop Flashlight testing utility\""
@@ -107,6 +105,13 @@ LABELS=(
   "--label" "org.opencontainers.image.licenses=\"MIT\""
   "--label" "org.opencontainers.image.created=\"$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")\""
 );
+
+TARGET_IMAGE_NAME=${TARGET_IMAGE_NAME:-prestashop/prestashop-flashlight}
+
+# if the tag is defined there won't be auto
+if [ -n "$TARGET_IMAGE_TAG" ]; then
+  TARGET_IMAGE=${TARGET_IMAGE_NAME}:${TARGET_IMAGE_TAG}
+fi
 
 get_latest_prestashop_version() {
   curl --silent --show-error --fail --location --request GET \
@@ -181,26 +186,26 @@ get_target_images() {
   declare RES;
   if [ "$PS_VERSION" == "nightly" ]; then
     if [ "$OS_FLAVOUR" = "$DEFAULT_OS" ]; then
-      RES="-t ${BASE_DOCKER_IMAGE}:nightly-${SERVER_FLAVOUR}";
+      RES="-t ${TARGET_IMAGE_NAME}:nightly-${SERVER_FLAVOUR}";
     else 
-      RES="-t ${BASE_DOCKER_IMAGE}:nightly-${OS_FLAVOUR}-${SERVER_FLAVOUR}";
+      RES="-t ${TARGET_IMAGE_NAME}:nightly-${OS_FLAVOUR}-${SERVER_FLAVOUR}";
     fi
   else
     if [ "$PS_VERSION" = "$(get_latest_prestashop_version)" ] \
       && [ "$OS_FLAVOUR" = "$DEFAULT_OS" ] \
       && [ "$PHP_VERSION" = "$(get_recommended_php_version "$PS_VERSION")" ] \
       && [ "$SERVER_FLAVOUR" = "$DEFAULT_SERVER" ]; then
-      RES="-t ${BASE_DOCKER_IMAGE}:latest";
+      RES="-t ${TARGET_IMAGE_NAME}:latest";
     fi
     if [ "$OS_FLAVOUR" = "$DEFAULT_OS" ]; then
-      RES="${RES} -t ${BASE_DOCKER_IMAGE}:${PS_VERSION}-${PHP_VERSION}-${SERVER_FLAVOUR}";
+      RES="${RES} -t ${TARGET_IMAGE_NAME}:${PS_VERSION}-${PHP_VERSION}-${SERVER_FLAVOUR}";
       if [ "$PHP_VERSION" = "$(get_recommended_php_version "$PS_VERSION")" ]; then
-        RES="${RES} -t ${BASE_DOCKER_IMAGE}:${PS_VERSION}-${SERVER_FLAVOUR}";
-        RES="${RES} -t ${BASE_DOCKER_IMAGE}:php-${PHP_VERSION}-${SERVER_FLAVOUR}";
+        RES="${RES} -t ${TARGET_IMAGE_NAME}:${PS_VERSION}-${SERVER_FLAVOUR}";
+        RES="${RES} -t ${TARGET_IMAGE_NAME}:php-${PHP_VERSION}-${SERVER_FLAVOUR}";
       fi
     fi
-    RES="${RES} -t ${BASE_DOCKER_IMAGE}:${PS_VERSION}-${PHP_BASE_IMAGE}-${SERVER_FLAVOUR}";
-    RES="${RES} -t ${BASE_DOCKER_IMAGE}:${PS_VERSION}-${OS_FLAVOUR}-${SERVER_FLAVOUR}";
+    RES="${RES} -t ${TARGET_IMAGE_NAME}:${PS_VERSION}-${PHP_BASE_IMAGE}-${SERVER_FLAVOUR}";
+    RES="${RES} -t ${TARGET_IMAGE_NAME}:${PS_VERSION}-${OS_FLAVOUR}-${SERVER_FLAVOUR}";
   fi
   echo "$RES";
 }
@@ -219,10 +224,15 @@ NODE_VERSION=$(get_recommended_nodejs_version "$PS_VERSION");
 if [ "$PHP_BASE_IMAGE" == "null" ]; then
   error "Could not find a PHP flavour for $OS_FLAVOUR + $SERVER_FLAVOUR + $PHP_VERSION" 2;
 fi
+
 if [ -z "${TARGET_IMAGE:+x}" ]; then
   read -ra TARGET_IMAGES <<<"$(get_target_images "$PHP_BASE_IMAGE" "$PS_VERSION" "$PHP_VERSION" "$OS_FLAVOUR")"
+  read -ra TARGET_BASE_IMAGES <<<"-t $TARGET_IMAGE_NAME:base-${PHP_BASE_IMAGE}-${SERVER_FLAVOUR}"
+  BASE_DOCKER_IMAGE="$TARGET_IMAGE_NAME:base-${PHP_BASE_IMAGE}-${SERVER_FLAVOUR}"
 else
   read -ra TARGET_IMAGES <<<"-t $TARGET_IMAGE"
+  read -ra TARGET_BASE_IMAGES <<<"-t $TARGET_IMAGE"
+  BASE_DOCKER_IMAGE="$TARGET_IMAGE"
 fi
 
 # If ZIP_SOURCE is not defined, set it based on PS_VERSION
@@ -247,14 +257,14 @@ fi
 
 # Build the docker image
 # ----------------------
-CACHE_IMAGE=$BASE_DOCKER_IMAGE:base-${PHP_BASE_IMAGE}-${SERVER_FLAVOUR}
 if [ "$DRY_RUN" == "true" ]; then
   docker() {
     echo docker "$@"
   }
 fi
 
-docker pull "$CACHE_IMAGE" 2> /dev/null || REBUILD_BASE='true';
+# acts as a cache if available
+docker pull "$BASE_DOCKER_IMAGE" 2> /dev/null || REBUILD_BASE='true';
 
 if [ "$REBUILD_BASE" == "true" ]; then
   echo "building base for $PHP_BASE_IMAGE $SERVER_FLAVOUR ($TARGET_PLATFORM)"
@@ -262,7 +272,7 @@ if [ "$REBUILD_BASE" == "true" ]; then
     --progress=plain \
     --file "./docker/$OS_FLAVOUR-base.Dockerfile" \
     --platform "$TARGET_PLATFORM" \
-    --cache-from type=registry,ref="$CACHE_IMAGE" \
+    --cache-from type=registry,ref="$BASE_DOCKER_IMAGE" \
     --cache-to type=inline \
     --build-arg PHP_BASE_IMAGE="$PHP_BASE_IMAGE" \
     --build-arg PHP_VERSION="$PHP_VERSION" \
@@ -270,7 +280,7 @@ if [ "$REBUILD_BASE" == "true" ]; then
     --build-arg GIT_SHA="$GIT_SHA" \
     --build-arg SERVER_FLAVOUR="$SERVER_FLAVOUR" \
     "${LABELS[@]}" \
-    --tag "$BASE_DOCKER_IMAGE:base-${PHP_BASE_IMAGE}-${SERVER_FLAVOUR}" \
+    "${TARGET_BASE_IMAGES[@]}" \
     "$([ "${PUSH}" == "true" ] && echo "--push" || echo "--load")" \
     .
 fi
@@ -280,15 +290,16 @@ if [ "$BASE_ONLY" == "false" ]; then
     --progress=plain \
     --file "./docker/flashlight.Dockerfile" \
     --platform "$TARGET_PLATFORM" \
-    --cache-from type=registry,ref="$CACHE_IMAGE" \
+    --cache-from type=registry,ref="$BASE_DOCKER_IMAGE" \
     --cache-to type=inline \
+    --build-arg BASE_DOCKER_IMAGE="$BASE_DOCKER_IMAGE" \
     --build-arg PHP_BASE_IMAGE="$PHP_BASE_IMAGE" \
     --build-arg PS_VERSION="$PS_VERSION" \
     --build-arg PHP_VERSION="$PHP_VERSION" \
     --build-arg GIT_SHA="$GIT_SHA" \
     --build-arg ZIP_SOURCE="$ZIP_SOURCE" \
     --build-arg SERVER_FLAVOUR="$SERVER_FLAVOUR" \
-    --build-arg BASE_DOCKER_IMAGE="$BASE_DOCKER_IMAGE" \
+    --build-arg TARGET_IMAGE_NAME="$TARGET_IMAGE_NAME" \
     "${LABELS[@]}" \
     "${TARGET_IMAGES[@]}" \
     "$([ "${PUSH}" == "true" ] && echo "--push" || echo "--load")" \

--- a/docker/alpine-base.Dockerfile
+++ b/docker/alpine-base.Dockerfile
@@ -41,6 +41,6 @@ RUN version="$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;")" \
   && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
 # Install and configure MariaDB
-RUN adduser --system mysql \
+RUN adduser -D -s /sbin/nologin mysql \
   && apk --no-cache add -U --no-commit-hooks --no-scripts mariadb;
 COPY ./assets/mariadb-server.cnf /etc/my.cnf.d/mariadb-server.cnf

--- a/docker/flashlight.Dockerfile
+++ b/docker/flashlight.Dockerfile
@@ -2,9 +2,8 @@
 # Flashlight install and dump SQL
 # --------------------------------
 ARG BASE_DOCKER_IMAGE
-ARG PHP_BASE_IMAGE
 ARG SERVER_FLAVOUR
-FROM ${BASE_DOCKER_IMAGE}:base-${PHP_BASE_IMAGE}-${SERVER_FLAVOUR} AS build-and-dump
+FROM ${BASE_DOCKER_IMAGE} AS build-and-dump
 ARG PS_VERSION
 ARG PHP_VERSION
 ARG GIT_SHA
@@ -42,9 +41,8 @@ RUN sh /hydrate.sh
 # Flashlight final image
 # -----------------------
 ARG BASE_DOCKER_IMAGE
-ARG PHP_BASE_IMAGE
 ARG SERVER_FLAVOUR
-FROM ${BASE_DOCKER_IMAGE}:base-${PHP_BASE_IMAGE}-${SERVER_FLAVOUR} AS prestashop-flashlight
+FROM ${BASE_DOCKER_IMAGE} AS prestashop-flashlight
 ARG PS_VERSION
 ARG PHP_VERSION
 ARG PHP_BASE_IMAGE

--- a/php-flavours.json
+++ b/php-flavours.json
@@ -8,7 +8,7 @@
     "debian": "7.0-fpm-jessie",
     "phpunit": "6.5.14",
     "php_cs_fixer": "v2.19.3",
-    "phpstan": "0.9.3",
+    "phpstan": "0.9.2",
     "xdebug": "2.7.2"
   },
   "7.1": {

--- a/release-base.sh
+++ b/release-base.sh
@@ -2,7 +2,6 @@
 set -eu
 
 PHP_VERSIONS="$(jq -r 'keys | join(" ")' ./php-flavours.json)"
-
 for PHP_VERSION in $PHP_VERSIONS; do
   echo "Publishing Alpine Base for $PHP_VERSION"
   gh workflow run docker-base-publish.yml \
@@ -12,7 +11,8 @@ for PHP_VERSION in $PHP_VERSIONS; do
     --field php_version="$PHP_VERSION"
 done
 
-for PHP_VERSION in $PHP_VERSIONS; do
+PHP_DEBIAN_VERSIONS="8.0 8.1 8.2 8.3"
+for PHP_VERSION in $PHP_DEBIAN_VERSIONS; do
   echo "Publishing Debian Base for $PHP_VERSION"
   gh workflow run docker-base-publish.yml \
     --repo prestashop/prestashop-flashlight \

--- a/release.sh
+++ b/release.sh
@@ -2,6 +2,7 @@
 set -eu
 EXCLUDED_TAGS='\/1.5|\/1.6.0|alpha|beta|rc|RC|\^'
 PRESTASHOP_TAGS=$(git ls-remote --tags git@github.com:PrestaShop/PrestaShop.git | cut -f2 | grep -Ev $EXCLUDED_TAGS | cut -d '/' -f3 | sort -r -V)
+PRESTASHOP_TAGS_DEBIAN=$(echo "$PRESTASHOP_TAGS" | grep -Ev '^1.7|1.6')
 # PRESTASHOP_MAJOR_TAGS=$(
 #   MAJOR_TAGS=""
 #   for VERSION in $PRESTASHOP_TAGS; do
@@ -52,12 +53,15 @@ publish() {
 }
 
 # Latest
-publish --field ps_version=latest
+publish --field ps_version=latest --field os_flavour=alpine
 publish --field ps_version=latest --field os_flavour=debian
 
 # Build & publish every prestashop version with recommended PHP version
 for PS_VERSION in $PRESTASHOP_TAGS; do
-  publish --field ps_version="$PS_VERSION"
+  publish --field ps_version="$PS_VERSION" --field os_flavour=alpine
+done
+
+for PS_VERSION in $PRESTASHOP_TAGS_DEBIAN; do
   publish --field ps_version="$PS_VERSION" --field os_flavour=debian
 done
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix the build of images with old distros for PHP 5.6 and add more tests in the CI workflow.
| Type?             | bug fix + enhancements
| BC breaks?        | **yes**. `CUSTOM_BASE_IMAGE` has been removed, as this behavior is now configurable for both base and final images through `TARGET_IMAGE` or `TARGET_IMAGE_NAME` + `TARGET_IMAGE_TAG` (new)
| Deprecations?     | no, but as the build script API change, please do not use `CUSTOM_BASE_IMAGE` nor `--custom-base-image` starting from now
| Fixes      | PrestaShop 8.3 now proposes a `parameters.yml.dist` file. TARGET_IMAGE related fixes confusing with base image variables.
| How to test?      | BASE_ONLY=true TARGET_PLATFORM=linux/arm64 PHP_VERSION=5.6 ./build.sh 
