### PR TITLE
Fixed disabling xdebug too early

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -96,7 +96,7 @@ jobs:
         run: docker run --env PS_DOMAIN='localhost:80' --entrypoint phpstan flashlight:${{ matrix.ps_version }} --version
 
       - name: Test the image tooling(xdebug)
-        run: docker run --env PS_DOMAIN='localhost:80' --entrypoint bash flashlight:${{ matrix.ps_version }} -c 'php -m -c | grep xdebug'
+        run: docker run --env PS_DOMAIN='localhost:80' --env XDEBUG_ENABLED=true --entrypoint bash flashlight:${{ matrix.ps_version }} -c 'php -m -c | grep xdebug'
 
   docker_build_base_alpine:
     name: "Docker build: PrestaShop with PHP ${{ matrix.php_version }} alpine"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -102,7 +102,7 @@ jobs:
           chmod +x new_run.sh
           docker run --rm \
             --env PS_DOMAIN='localhost:80' \
-            --env XDEBUG_ENABLED=true
+            --env XDEBUG_ENABLED=true \
             --env DRY_RUN='true' \
             --entrypoint /tmp/new_run.sh \
             -v ./new_run.sh:/tmp/new_run.sh \

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -95,8 +95,30 @@ jobs:
       - name: Test the image tooling(phpstan)
         run: docker run --env PS_DOMAIN='localhost:80' --entrypoint phpstan flashlight:${{ matrix.ps_version }} --version
 
-      - name: Test the image tooling(xdebug)
-        run: docker run --env PS_DOMAIN='localhost:80' --env XDEBUG_ENABLED=true --entrypoint bash flashlight:${{ matrix.ps_version }} -c 'php -m -c | grep xdebug'
+      - name: Test the image tooling(xdebug enabled)
+        run: |
+          echo '#!/bin/sh' > new_run.sh
+          echo '/run.sh && php -m -c | grep xdebug' >> new_run.sh
+          chmod +x new_run.sh
+          docker run --rm \
+            --env PS_DOMAIN='localhost:80' \
+            --env XDEBUG_ENABLED=true
+            --env DRY_RUN='true' \
+            --entrypoint /tmp/new_run.sh \
+            -v ./new_run.sh:/tmp/new_run.sh \
+            flashlight:${{ matrix.ps_version }}
+
+      - name: Test the image tooling(xdebug disabled)
+        run: |
+          echo '#!/bin/sh' > new_run.sh
+          echo '/run.sh && ! php -m -c | grep xdebug' >> new_run.sh
+          chmod +x new_run.sh
+          docker run --rm \
+            --env PS_DOMAIN='localhost:80' \
+            --env DRY_RUN='true' \
+            --entrypoint /tmp/new_run.sh \
+            -v ./new_run.sh:/tmp/new_run.sh \
+            flashlight:${{ matrix.ps_version }}
 
   docker_build_base_alpine:
     name: "Docker build: PrestaShop with PHP ${{ matrix.php_version }} alpine"

--- a/assets/alpine-base-install.sh
+++ b/assets/alpine-base-install.sh
@@ -125,6 +125,8 @@ if [ "$PHP_XDEBUG" != "null" ]; then
   pecl install "xdebug-$PHP_XDEBUG"
   docker-php-ext-enable xdebug
 fi
+# Disables the xdebug extension from php.ini otherwise it's never really disabled
+sed -i 's~zend_extension="xdebug.so"~;zend_extension="xdebug.so"~' "$PHP_INI_DIR/php.ini"
 
 # Install Node.js (shipping yarn and npm) and pnpm
 if [ "0.0.0" != "$NODE_VERSION" ]; then

--- a/assets/debian-base-install.sh
+++ b/assets/debian-base-install.sh
@@ -145,6 +145,8 @@ if [ "$PHP_XDEBUG" != "null" ]; then
   pecl install "xdebug-$PHP_XDEBUG"
   docker-php-ext-enable xdebug
 fi
+# Disables the xdebug extension from php.ini otherwise it's never really disabled
+sed -i 's~zend_extension="xdebug.so"~;zend_extension="xdebug.so"~' "$PHP_INI_DIR/php.ini"
 
 # Install Node.js (shipping yarn and npm) and pnpm
 if [ "0.0.0" != "$NODE_VERSION" ]; then

--- a/assets/php-configuration.sh
+++ b/assets/php-configuration.sh
@@ -51,8 +51,6 @@ cat <<EOF >  "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini"
 ;xdebug.start_with_request = yes
 ;xdebug.discover_client_host = 1
 EOF
-# Disables the xdebug extension from php.ini otherwise it's never really disabled
-sed -i 's~zend_extension="xdebug.so"~;zend_extension="xdebug.so"~' "$PHP_INI_DIR/php.ini"
 
 # Remove php assets that might have been installed by package unaware of $PHP_INI_DIR
 rm -rf /etc/php* /usr/lib/php*


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Xdebug was disabled in php.ini before it was installed
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Sponsor company   | Prestashop
