### PR TITLE
Set FR as default country to force euro currency to be installed

### DIFF
--- a/assets/hydrate.sh
+++ b/assets/hydrate.sh
@@ -16,7 +16,7 @@ export PS_DOMAIN="localhost:80" \
   ADMIN_MAIL=admin@prestashop.com \
   ADMIN_PASSWD=prestashop \
   PS_LANGUAGE=en \
-  PS_COUNTRY=GB \
+  PS_COUNTRY=FR \
   PS_FOLDER_ADMIN=admin-dev \
   DB_SOCKET=/run/mysqld/mysqld.sock
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Sets FR as default country to force euro currency to be installed and fix a inconsistency concerning localization packs
| Type?             | bug fix
| BC breaks?        | yes
| Deprecations?     | no
| Sponsor company   | Prestashop
