### PR TITLE
fix customizing MYSQL_USER

### DIFF
--- a/assets/run.sh
+++ b/assets/run.sh
@@ -152,7 +152,7 @@ END
         -e "s~host' => '127.0.0.1'~host' => '$MYSQL_HOST'~" \
         -e "s~port' => ''~port' => '$MYSQL_PORT'~" \
         -e "s~name' => 'prestashop'~name' => '$MYSQL_DATABASE'~" \
-        -e "s~user' => 'root'~user' => '$MYSQL_USER'~" \
+        -e "s~user' => 'prestashop'~user' => '$MYSQL_USER'~" \
         -e "s~password' => 'prestashop'~password' => '$MYSQL_PASSWORD'~" \
         -e "s~database_engine' => 'InnoDB',~database_engine' => 'InnoDB',\n    'server_version' => '$MYSQL_VERSION',~" \
       "$PS_FOLDER/app/config/parameters.php"
@@ -161,7 +161,7 @@ END
     sed -i \
         -e "s~127.0.0.1:3306~$MYSQL_HOST:$MYSQL_PORT~" \
         -e "s~_DB_NAME_', 'prestashop~_DB_NAME_', '$MYSQL_DATABASE~" \
-        -e "s~_DB_USER_', 'root~_DB_USER_', '$MYSQL_USER~" \
+        -e "s~_DB_USER_', 'prestashop~_DB_USER_', '$MYSQL_USER~" \
         -e "s~_DB_PASSWD_', 'prestashop~_DB_PASSWD_', '$MYSQL_PASSWORD~" \
       "$PS_16_CONFIG_PARAMETERS"
   fi


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Customizing MYSQL_USER doesn't seem to work, this PR attempts to fix that
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #153 
| Sponsor company   | -
| How to test?      | Change MYSQL_USER in compose.yaml to something other than "prestashop" and try starting the container

Startup script seems to assume that the default database username is "root", while the actual default is set during the container build here, and it's "prestashop":

https://github.com/PrestaShop/prestashop-flashlight/blob/main/assets/hydrate.sh#L14

This PR changes the startup script. Alternative fix would be to change the default to "root", not sure which would be preferred.
