### PR TITLE
Run CI on 1.7.5 instead of 1.7.6

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ps_version: ["1.6.1.24", "1.7.6.9", "1.7.7.8", "1.7.8.11", "8.1.7", "9.0.3", "9.1.0"]
+        ps_version: ["1.6.1.24", "1.7.5.2", "1.7.7.8", "1.7.8.11", "8.1.7", "9.0.3", "9.1.0"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |  Run CI on 1.7.5 instead of 1.7.6 because of https://github.com/PrestaShop/prestashop-flashlight/issues/181
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Work around https://github.com/PrestaShop/prestashop-flashlight/issues/181
| Sponsor company   | PrestaShop
| How to test?      | See https://github.com/PrestaShop/prestashop-flashlight/issues/181
