### PR TITLE
chore: add newly published PrestaShop versions

### DIFF
--- a/prestashop-versions.json
+++ b/prestashop-versions.json
@@ -92,7 +92,22 @@
       "9.1.0-3.0-beta.1": "https://assets.prestashop3.com/dst/edition/corporate/9.1.0-3.0-beta.1/prestashop_edition_basic_version_9.1.0-3.0-beta.1.zip",
       "9.1.0-4.0-rc.1": "https://assets.prestashop3.com/dst/edition/corporate/9.1.0-4.0-rc.1/prestashop_edition_basic_version_9.1.0-4.0-rc.1.zip",
       "9.1.0-4.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.0-4.0/prestashop_edition_basic_version_9.1.0-4.0.zip",
-      "9.1.1-4.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.1-4.0/prestashop_edition_basic_version_9.1.1-4.0.zip"
+      "9.1.1-4.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.1-4.0/prestashop_edition_basic_version_9.1.1-4.0.zip",
+      "9.1.2-5.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.2-5.0/prestashop_edition_basic_version_9.1.2-5.0.zip",
+      "9.1.3-5.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.3-5.0/prestashop_edition_basic_version_9.1.3-5.0.zip",
+      "9.1.4-5.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.4-5.0/prestashop_edition_basic_version_9.1.4-5.0.zip"
+    }
+  },
+  "^9.2": {
+    "php": {
+      "recommended": "8.5",
+      "compatible": ["8.1", "8.2", "8.3", "8.4", "8.5"]
+    },
+    "nodejs": {
+      "recommended": "16.16.0"
+    },
+    "zip_sources": {
+      "9.2.0-6.0-beta.1": "https://assets.prestashop3.com/dst/edition/corporate/9.2.0-6.0-beta.1/prestashop_edition_basic_version_9.2.0-6.0-beta.1.zip"
     }
   },
   "nightly": {


### PR DESCRIPTION
Automated update of `prestashop-versions.json`, every zip URL below returned a 200.

## New PrestaShop versions

- `9.1.2` → `9.1.2-5.0` under `^9.1` ([zip](https://assets.prestashop3.com/dst/edition/corporate/9.1.2-5.0/prestashop_edition_basic_version_9.1.2-5.0.zip))
- `9.1.3` → `9.1.3-5.0` under `^9.1` ([zip](https://assets.prestashop3.com/dst/edition/corporate/9.1.3-5.0/prestashop_edition_basic_version_9.1.3-5.0.zip))
- `9.1.4` → `9.1.4-5.0` under `^9.1` ([zip](https://assets.prestashop3.com/dst/edition/corporate/9.1.4-5.0/prestashop_edition_basic_version_9.1.4-5.0.zip))
- `9.2.0-beta.1` → `9.2.0-6.0-beta.1` under `^9.2` ([zip](https://assets.prestashop3.com/dst/edition/corporate/9.2.0-6.0-beta.1/prestashop_edition_basic_version_9.2.0-6.0-beta.1.zip))

## New version branches

- `^9.2`: recommended PHP `8.5`, compatible `8.1, 8.2, 8.3, 8.4, 8.5`, taken from the upstream CI matrix of `9.2.0-beta.1`.
  NodeJS `16.16.0` was copied from the previous branch: **please check it manually**.

Generated by `find-new-prestashop-versions.sh`.
