### PR TITLE
chore: add newly published PrestaShop versions

### DIFF
--- a/prestashop-versions.json
+++ b/prestashop-versions.json
@@ -95,7 +95,8 @@
       "9.1.1-4.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.1-4.0/prestashop_edition_basic_version_9.1.1-4.0.zip",
       "9.1.2-5.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.2-5.0/prestashop_edition_basic_version_9.1.2-5.0.zip",
       "9.1.3-5.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.3-5.0/prestashop_edition_basic_version_9.1.3-5.0.zip",
-      "9.1.4-5.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.4-5.0/prestashop_edition_basic_version_9.1.4-5.0.zip"
+      "9.1.4-5.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.4-5.0/prestashop_edition_basic_version_9.1.4-5.0.zip",
+      "9.1.5-5.0": "https://assets.prestashop3.com/dst/edition/corporate/9.1.5-5.0/prestashop_edition_basic_version_9.1.5-5.0.zip"
     }
   },
   "^9.2": {


### PR DESCRIPTION
Automated update of `prestashop-versions.json`, every zip URL below returned a 200.

## New PrestaShop versions

- `9.1.5` → `9.1.5-5.0` under `^9.1` ([zip](https://assets.prestashop3.com/dst/edition/corporate/9.1.5-5.0/prestashop_edition_basic_version_9.1.5-5.0.zip))

Generated by `find-new-prestashop-versions.sh`.
